### PR TITLE
🧹 Fix telemetry integration and update package references

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,7 +31,7 @@ The dashboard provides a real-time view of your training pipeline:
 
 ```bash
 # Start the dashboard (interactive mode)
-python -m autotrain.dashboard
+python -m heidi_engine.dashboard
 
 # Or use the CLI entrypoint
 autotrain-dashboard
@@ -43,7 +43,7 @@ Get ML configuration recommendations for your hardware:
 
 ```bash
 # Get recommendations (JSON output)
-python -m autotrain.telemetry status --json
+python -m heidi_engine.telemetry status --json
 
 # Or use the HTTP status server
 autotrain-serve --port 7779
@@ -64,17 +64,17 @@ python scripts/menu.py
 
 ## Next Steps
 
-- **Configuration**: Edit `autotrain/config.yaml` or use `python scripts/menu.py` to configure training parameters
-- **Monitoring**: Run `python -m autotrain.dashboard` in a separate terminal to monitor progress
+- **Configuration**: Edit `heidi_engine/config.yaml` or use `python scripts/menu.py` to configure training parameters
+- **Monitoring**: Run `python -m heidi_engine.dashboard` in a separate terminal to monitor progress
 - **Fine-tuning**: See [Fine-tuning Guide](.local/ml/fine_tuning_guide.md) for detailed ML setup
 
 ## Common Commands
 
 | Command | Description |
 |---------|-------------|
-| `python -m autotrain.dashboard` | Launch real-time dashboard |
-| `python -m autotrain.http --port 7779` | Start HTTP status server |
-| `python -m autotrain.telemetry status` | Show current run status |
+| `python -m heidi_engine.dashboard` | Launch real-time dashboard |
+| `python -m heidi_engine.http --port 7779` | Start HTTP status server |
+| `python -m heidi_engine.telemetry status` | Show current run status |
 | `python scripts/menu.py` | Interactive menu controller |
 | `./scripts/loop.sh --help` | Show training loop options |
 
@@ -89,7 +89,7 @@ All parameters can be configured via environment variables:
 | `BASE_MODEL` | microsoft/phi-2 | Base model for fine-tuning |
 | `SEQ_LEN` | 2048 | Maximum sequence length |
 | `TRAIN_STEPS` | 500 | Training steps per round |
-| `AUTOTRAIN_DIR` | ~/.local/autotrain | Output directory |
+| `AUTOTRAIN_DIR` | ~/.local/heidi_engine | Output directory |
 
 ## Troubleshooting
 

--- a/scripts/loop.sh
+++ b/scripts/loop.sh
@@ -12,7 +12,7 @@ set -o pipefail
 #     pipeline for building an autonomous coding agent.
 #
 # INTEGRATION:
-#     This script integrates with autotrain/telemetry.py for:
+#     This script integrates with heidi_engine/telemetry.py for:
 #     - Real-time event emission (see --emit option)
 #     - State management (run_id, counters, usage)
 #     - Graceful stop/pause/resume support
@@ -28,7 +28,7 @@ set -o pipefail
 #     BASE_MODEL          Base model to fine-tune (default: microsoft/phi-2)
 #     TEACHER_MODEL       Teacher model for generation (default: gpt-4o-mini)
 #     VAL_RATIO           Validation split ratio (default: 0.1)
-#     OUT_DIR             Output directory (default: ./autotrain)
+#     OUT_DIR             Output directory (default: ~/.local/heidi_engine)
 #     SEQ_LEN             Sequence length (default: 2048)
 #     BATCH_SIZE          Batch size (default: 1)
 #     GRAD_ACCUM          Gradient accumulation steps (default: 8)
@@ -48,7 +48,7 @@ set -o pipefail
 #     Rate-limiting: 5 min between train attempts.
 #
 # CONFIG FILE:
-#     Configuration can also be saved to autotrain/config.yaml
+#     Configuration can also be saved to $OUT_DIR/config.yaml
 #     Run ./scripts/menu.py to configure interactively
 #
 # HPO:
@@ -61,13 +61,13 @@ set -o pipefail
 #     - Resume: Clears pause_requested, continues from last stage
 #
 # DASHBOARD:
-#     Run 'python -m autotrain.dashboard' in another terminal to see live progress
+#     Run 'autotrain-dashboard' in another terminal to see live progress
 #
 # VRAM-SAFE DEFAULTS (RTX 2080 Ti - 11GB):
 #     SEQ_LEN=2048, BATCH_SIZE=1, GRAD_ACCUM=8, LORA_R=64
 #
 # OUTPUT STRUCTURE:
-#     autotrain/
+#     heidi_engine/
 #     ├── runs/<run_id>/
 #     │   ├── state.json          # Current run state (counters, status)
 #     │   ├── events.jsonl        # Event stream for dashboard
@@ -115,6 +115,8 @@ TELEMETRY_AVAILABLE=false
 if [ "$HEIDI_TELEMETRY" -eq 1 ] 2>/dev/null; then
     if python3 -c "import heidi_engine.telemetry" 2>/dev/null; then
         TELEMETRY_AVAILABLE=true
+    else
+        log_warn "HEIDI_TELEMETRY=1 but heidi_engine.telemetry module not found; disabling telemetry."
     fi
 fi
 


### PR DESCRIPTION
The task was to fix a broken telemetry import in `scripts/loop.sh` where it was using `autotrain.telemetry` instead of `heidi_engine.telemetry`. Upon inspection, the functional import in the current state of `scripts/loop.sh` had already been updated to `heidi_engine.telemetry`, but the telemetry check was silent on failure, and many comments and documentation files still referred to the old `autotrain` package.

I have:
1. Added a robust warning in `scripts/loop.sh` that alerts the user if telemetry is enabled (`HEIDI_TELEMETRY=1`) but the module cannot be imported.
2. Updated all comments in `scripts/loop.sh` to reflect the correct package and directory structure.
3. Updated `docs/getting-started.md` to use the correct `python -m heidi_engine` commands for the dashboard and telemetry status, as well as fixing the default output directory.

Verification:
- Ran `bash -n scripts/loop.sh` to confirm syntax.
- Ran `./scripts/loop.sh --help` to verify basic execution.
- Verified the new warning logic with a test script.
- Ran the full test suite with `pytest` (42 passed).

---
*PR created automatically by Jules for task [12356655283805357040](https://jules.google.com/task/12356655283805357040) started by @heidi-dang*