### PR TITLE
ci(repo-hygiene): add workflow_dispatch

### DIFF
--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -1,5 +1,7 @@
 name: repo-hygiene
-on: [pull_request]
+on:
+  pull_request:
+  workflow_dispatch:
 jobs:
   forbid-venv:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Allows manually running the repo-hygiene workflow from the Actions tab.