### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Telemetry

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal - Security Learnings
+
+## 2025-01-24 - Path Traversal in Telemetry Run IDs
+**Vulnerability:** Path Traversal in `get_run_dir` and `_rotate_events_log`.
+**Learning:** The application trusted the `run_id` provided via environment variables or CLI arguments to construct file system paths. This allowed directory traversal using `..` sequences, which could lead to arbitrary directory creation or unauthorized file rotation/deletion.
+**Prevention:** Always sanitize user-provided identifiers that are used in path construction. Using `Path(input).name` is an effective way to extract only the last component and prevent traversal. Additionally, use `.resolve()` and verify that the final path is a child of the expected root directory as a defense-in-depth measure.

--- a/heidi_engine/dashboard.py
+++ b/heidi_engine/dashboard.py
@@ -1227,7 +1227,7 @@ def main():
         If no run specified, shows interactive selection
     """
     global run_id, current_view
-    
+
     parser = argparse.ArgumentParser(
         prog="heidi-engine dashboard",
         description="Heidi Engine Real-Time Dashboard"

--- a/heidi_engine/telemetry.py
+++ b/heidi_engine/telemetry.py
@@ -358,12 +358,20 @@ def get_run_dir(run_id: Optional[str] = None) -> Path:
         Creates runs/<run_id>/ directory structure.
         All run-specific files go here.
 
+    SECURITY:
+        - Uses Path(run_id).name to sanitize input and prevent path traversal
+        - Ensures run directory is always inside AUTOTRAIN_DIR/runs/
+
     TUNABLE:
         - Modify directory structure by changing path construction
     """
     if run_id is None:
         run_id = get_run_id()
-    return Path(AUTOTRAIN_DIR) / "runs" / run_id
+
+    # Hardening: use only the name part of run_id to prevent path traversal
+    # If run_id is "../../etc/passwd", safe_run_id becomes "passwd"
+    safe_run_id = Path(run_id).name
+    return Path(AUTOTRAIN_DIR) / "runs" / safe_run_id
 
 
 def get_events_path(run_id: Optional[str] = None) -> Path:
@@ -656,7 +664,7 @@ def get_state(run_id: Optional[str] = None) -> Dict[str, Any]:
     HOW IT WORKS:
         - Reads state.json file
         - Returns empty state if file doesn't exist
-    
+
     ARGS:
         run_id: Run to read (defaults to current run)
 
@@ -687,44 +695,44 @@ def get_state(run_id: Optional[str] = None) -> Dict[str, Any]:
 def resolve_status(state: Dict[str, Any]) -> str:
     """
     Resolve run status from on-disk metadata.
-    
+
     STATUS VALUES:
         - idle: No active run, or run_id present but no events
         - running: Worker active / stop not requested / still processing
         - stopped: stop_requested=true or pipeline complete
         - error: last_error present or health degraded
-    
+
     HOW IT WORKS:
         - Checks stop_requested flag
         - Checks status field
         - Checks for error indicators
-    
+
     ARGS:
         state: State dictionary from state.json
-    
+
     RETURNS:
         Status string: idle, running, stopped, error
     """
     # Explicit stop requested
     if state.get("stop_requested", False):
         return "stopped"
-    
+
     # Check explicit status first
     status = state.get("status", "")
     if status in ("running", "completed", "stopped", "error"):
         return status
-    
+
     # Check for errors
     if state.get("last_error") or state.get("health") == "degraded":
         return "error"
-    
+
     # Check if there's an active run_id but no recent activity
     run_id = state.get("run_id")
     if run_id:
         # Has run_id - check for activity
         counters = state.get("counters", {})
         usage = state.get("usage", {})
-        
+
         # If there's any activity, consider it running
         if counters.get("teacher_generated", 0) > 0:
             return "running"
@@ -732,10 +740,10 @@ def resolve_status(state: Dict[str, Any]) -> str:
             return "running"
         if counters.get("train_step", 0) > 0:
             return "running"
-        
+
         # No activity - idle
         return "idle"
-    
+
     # Default to idle if no run_id
     return "idle"
 
@@ -1141,7 +1149,20 @@ def _rotate_events_log(events_file: Path) -> None:
     HOW IT WORKS:
         - Renames current log to .1, .2, etc.
         - Deletes oldest if over retention limit
+
+    SECURITY:
+        - Validates that rotation target is within the runs directory
+        - Prevents path traversal via malicious events_file path
     """
+    # Resolve paths for security validation
+    runs_root = (Path(AUTOTRAIN_DIR) / "runs").resolve()
+    resolved_file = events_file.resolve()
+
+    # Defense in depth: ensure the file being rotated is actually inside the runs directory
+    if runs_root not in resolved_file.parents:
+        print(f"[ERROR] Security violation: Attempted to rotate file outside runs directory: {resolved_file}", file=sys.stderr)
+        return
+
     run_dir = events_file.parent
 
     # Remove oldest if at limit
@@ -1517,7 +1538,7 @@ def main():
         python -m heidi_engine.telemetry emit <type> <message>
     """
     import argparse
-    
+
     parser = argparse.ArgumentParser(prog="heidi-engine telemetry")
     subparsers = parser.add_subparsers(dest="command")
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL

💡 **Vulnerability:** Path Traversal in Telemetry module.
The `get_run_dir` function was using raw `run_id` input (from environment variables or CLI) to construct paths, allowing an attacker to use `..` to escape the intended `runs/` directory. The `_rotate_events_log` function also lacked validation to ensure it was only operating on files within the `runs/` hierarchy.

🎯 **Impact:** 
An attacker could:
1. Create directories in arbitrary locations (e.g., `init_telemetry(run_id="../../malicious")`).
2. Rotate or delete files outside the intended directories if the `events_log` path was manipulated.

🔧 **Fix:**
1. Hardened `get_run_dir` to use only the `.name` part of the provided `run_id`.
2. Added a defense-in-depth check in `_rotate_events_log` that resolves the path and verifies it is a child of the `runs/` root.
3. Added `SECURITY:` docstring sections to highlight these measures.

✅ **Verification:**
- Confirmed the vulnerability with a reproduction script that successfully created a directory outside the `runs/` root before the fix.
- Verified that the fix correctly sanitizes malicious `run_id` strings (e.g., `../../malicious` becomes `malicious`).
- Verified that `_rotate_events_log` now explicitly blocks and logs attempts to rotate files outside the `runs/` root.
- All existing telemetry tests pass.
- Ruff linting checks pass.

---
*PR created automatically by Jules for task [8137947365068231499](https://jules.google.com/task/8137947365068231499) started by @heidi-dang*