### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in telemetry run directory

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Path Traversal in Telemetry Run Directory
+**Vulnerability:** The `get_run_dir` function in `heidi_engine/telemetry.py` used the `run_id` parameter directly to construct a file path without sanitization. This allowed an attacker to provide a malicious `run_id` (e.g., `../../../tmp/evil`) to write files outside of the intended directory structure.
+**Learning:** Even internal utility functions that handle identifiers can be vulnerable to path traversal if those identifiers are sourced from environment variables or CLI arguments that could be influenced by a malicious actor.
+**Prevention:** Always sanitize identifiers used in path construction. Using `Path(identifier).name` is an effective way to strip directory components and ensure the resulting path remains within the intended parent directory.

--- a/heidi_engine/telemetry.py
+++ b/heidi_engine/telemetry.py
@@ -358,12 +358,19 @@ def get_run_dir(run_id: Optional[str] = None) -> Path:
         Creates runs/<run_id>/ directory structure.
         All run-specific files go here.
 
+    SECURITY:
+        - Hardened against path traversal by using Path(run_id).name
+        - Ensures all run files stay within the runs/ directory
+
     TUNABLE:
         - Modify directory structure by changing path construction
     """
     if run_id is None:
         run_id = get_run_id()
-    return Path(AUTOTRAIN_DIR) / "runs" / run_id
+
+    # Path traversal protection: take only the filename part of run_id
+    safe_run_id = Path(run_id).name
+    return Path(AUTOTRAIN_DIR) / "runs" / safe_run_id
 
 
 def get_events_path(run_id: Optional[str] = None) -> Path:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,25 @@
+
+import pytest
+from pathlib import Path
+from heidi_engine.telemetry import get_run_dir, AUTOTRAIN_DIR
+
+def test_get_run_dir_path_traversal():
+    """Test that get_run_dir is protected against path traversal."""
+    malicious_run_id = "../../../tmp/evil_run"
+    run_dir = get_run_dir(malicious_run_id)
+
+    # The resolved path should be under AUTOTRAIN_DIR/runs
+    expected_parent = Path(AUTOTRAIN_DIR) / "runs"
+
+    # Check if the resolved run_dir is actually a child of the expected parent
+    # In the vulnerable version, this will be False if it escaped
+    assert expected_parent in run_dir.parents
+    assert run_dir.name == "evil_run"
+    assert ".." not in str(run_dir)
+
+def test_get_run_dir_safe():
+    """Test get_run_dir with a safe run_id."""
+    safe_run_id = "run_20240215_123456"
+    run_dir = get_run_dir(safe_run_id)
+    expected = Path(AUTOTRAIN_DIR) / "runs" / safe_run_id
+    assert run_dir == expected


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Path Traversal in `get_run_dir`
🎯 Impact: An attacker could influence the `run_id` (via environment variables or CLI) to read or write files outside the intended `runs/` directory.
🔧 Fix: Sanitized `run_id` using `Path(run_id).name` to ensure it stays within the `runs/` folder.
✅ Verification: Added `tests/test_security.py` with targeted path traversal test cases. Verified that all tests pass.

---
*PR created automatically by Jules for task [5976161782012006554](https://jules.google.com/task/5976161782012006554) started by @heidi-dang*