### PR TITLE
fix(openhei): robust SSE attach handling - normalize event shapes and add SSE unit tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,156 @@
+# AGENTS.md (instructions for coding agents)
+
+Heidi Engine is primarily a Python package (`heidi_engine/`) with:
+- CLI scripts in `scripts/`
+- pytest suite in `tests/`
+- optional C++ (daemon + Python extension) in `heidi_engine/cpp/`
+- optional ML tooling in `.local/ml/`
+
+Keep diffs small and avoid generated outputs.
+
+## Don’t edit / don’t commit
+
+Skip machine-local or huge dirs:
+`autotrain_repos/`, `.venv/`/`venv/`, `.local/ml/data/`, `.local/ml/runs/`,
+`.pytest_cache/`, `.ruff_cache/`, `__pycache__/`, `build/`, `*.so`.
+
+When searching, prefer `heidi_engine/`, `scripts/`, `tests/`, `docs/`.
+
+## Setup
+
+Python: `>=3.9` (source of truth: `pyproject.toml`; some docs mention 3.8).
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python3 -m pip install -U pip
+python3 -m pip install -e ".[dev]"
+```
+
+Optional extras:
+- HTTP: `python3 -m pip install -e ".[http]"`
+- ML (heavy): see `.local/ml/requirements-*.txt`
+
+## Lint
+
+Ruff config (in `pyproject.toml`): line length `100`, target `py39`, rules `E,F,W,I`, ignore `E501`.
+
+```bash
+ruff check heidi_engine scripts
+ruff check --fix heidi_engine scripts
+```
+
+Note: `tool.ruff.exclude` includes `tests/`; run `ruff check tests` explicitly if needed.
+
+## Tests
+
+```bash
+pytest -v
+pytest -v tests/test_openhei_teacher_parse.py
+pytest -v tests/test_openhei_teacher_parse.py::test_parse_openhei_jsonl_events_fails_closed_on_error_event
+pytest -v -k openhei
+```
+
+Many tests skip unless optional components/toolchains exist (`heidi_cpp`, `g++`, `node`, `go`).
+
+## Common commands
+
+Sanity checks:
+
+```bash
+python3 -m compileall -q .
+python3 -m heidi_engine.dashboard --help
+python3 -m heidi_engine.http --help
+python3 -m heidi_engine.telemetry status --json
+./scripts/loop.sh --help
+python3 scripts/menu.py --help
+autotrain-dashboard --help
+autotrain-serve --help
+heidi-telemetry status --json
+```
+
+Useful env vars (selected):
+- `RUN_ID`: current run identifier (telemetry/state)
+- `AUTOTRAIN_DIR`: run/output root (defaults to `~/.local/heidi-engine`)
+- `HEIDI_TELEMETRY=0`: disable telemetry emission in scripts that support it
+- `OPENHEI_ATTACH`, `OPENHEI_AGENT`, `OPENHEI_CLI`: OpenHei teacher/attach controls
+
+Note: some scripts/docs mention `~/.local/heidi_engine` (underscore); canonical path is `~/.local/heidi-engine`.
+
+## Build (optional C++)
+
+Python extension (`heidi_cpp`):
+
+```bash
+python3 -m pip install -U pybind11
+python3 setup_cpp.py build_ext --inplace
+```
+
+Daemon + C++ unit tests:
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j"$(nproc)"
+./build/cpp_core_tests
+./build/bin/heidid --help
+```
+
+Full local gate: `./scripts/ci_gate.sh` (compileall + CMake + gtests + selected pytest).
+
+## ML smoke (optional)
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python3 -m pip install -U pip
+python3 -m pip install -r .local/ml/requirements-ci.txt
+python3 -m pip install -e .
+.local/ml/scripts/prepare_data.sh .local/ml/data/raw_sample.jsonl
+.local/ml/scripts/train_adapter.sh --smoke-cpu --train-steps 2 --train .local/ml/data/train/train.jsonl --eval .local/ml/data/eval/val.jsonl
+python3 .local/ml/scripts/redaction_check.py --file .local/ml/data/train/train.jsonl --file .local/ml/data/eval/val.jsonl
+```
+
+Bootstrap helper: `.local/ml/scripts/setup_python_env.sh`.
+
+## Repo hygiene / security (CI-enforced)
+
+From `.github/workflows/repo-hygiene.yml`:
+- Never commit virtualenv artifacts (`.venv/`, `site-packages/`, `*.dist-info/`).
+- Never introduce hidden/bidi Unicode control characters.
+- Never introduce secret-like tokens in `scripts/` (GitHub/AWS/private keys/Slack).
+
+Operational guidance:
+- Redact subprocess output before logging (`heidi_engine.telemetry.redact_secrets`).
+- Enforce path containment for user-supplied paths (`heidi_engine/utils/security_util.py`).
+
+## Code style
+
+Imports:
+- Keep imports explicit; avoid `from x import *`.
+- Group stdlib / third-party / local; let Ruff (`I`) sort.
+
+Formatting:
+- Keep new code ~<= 100 cols; wrap docstrings reasonably.
+
+Types:
+- Type public APIs and non-trivial helpers.
+- File-by-file style varies (`typing.List` vs `list[str]`); match the file.
+- Keep `from __future__ import annotations` first when used.
+
+Naming:
+- `snake_case` for modules/functions/vars; `PascalCase` for classes; `UPPER_SNAKE_CASE` for constants.
+- Custom exceptions should be `SomethingError` and usually inherit `RuntimeError`.
+
+Error handling:
+- Prefer fail-fast/fail-closed for contracts (e.g. strict JSONL parsing).
+- Raise actionable errors; don’t silently swallow exceptions.
+- Optional deps: `try/except ImportError` with clear fallbacks.
+
+Testing:
+- Use `pytest.importorskip` for optional modules and `pytest.mark.skipif` for toolchain gates.
+- Gate integration tests via env vars (example: `OPENHEI_INTEGRATION=1`).
+
+## Cursor / Copilot rules
+
+No Cursor rules found (`.cursor/rules/` or `.cursorrules`).
+No Copilot instructions found (`.github/copilot-instructions.md`).

--- a/heidi_engine/teacher/openhei_teacher.py
+++ b/heidi_engine/teacher/openhei_teacher.py
@@ -2,15 +2,19 @@ from __future__ import annotations
 
 import json
 import os
+import random
+import socket
+import shlex
 import subprocess
 import sys
 import time
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
+from urllib.parse import quote
 
 from heidi_engine.telemetry import redact_secrets
 
@@ -25,6 +29,29 @@ def _bool_env(name: str, default: str = "0") -> bool:
 
 def _contains_session_not_found(text: str) -> bool:
     return "session not found" in (text or "").lower()
+
+
+def _is_retryable_error(text: str) -> bool:
+    lower = (text or "").lower()
+    if not lower:
+        return False
+    if "429" in lower or "too many requests" in lower or "rate limit" in lower:
+        return True
+    if "usage limit" in lower:
+        return True
+    if "timeout" in lower or "timed out" in lower or "temporarily unavailable" in lower:
+        return True
+    if "502" in lower or "503" in lower or "504" in lower or "bad gateway" in lower:
+        return True
+    return False
+
+
+def _sleep_backoff(base: float, attempt: int) -> None:
+    # Exponential backoff with jitter to avoid synchronized retry storms.
+    delay = base * (2**attempt)
+    delay = min(delay, 60.0)
+    delay += random.uniform(0.0, base)
+    time.sleep(delay)
 
 
 def _doc_url(attach_url: str) -> str:
@@ -132,6 +159,335 @@ Rules (Path B contract):
     return "".join(parts).strip()
 
 
+def _api_url(base: str, path: str) -> str:
+    b = (base or "").strip().rstrip("/")
+    p = (path or "").strip()
+    if not p.startswith("/"):
+        p = "/" + p
+    return b + p
+
+
+def _http_json(method: str, url: str, payload: Optional[dict], *, timeout_sec: float) -> Any:
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+    req = Request(url, method=method)
+    req.add_header("Accept", "application/json")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urlopen(req, data=data, timeout=timeout_sec) as resp:  # nosec
+            text = resp.read().decode("utf-8", errors="replace")
+    except HTTPError as e:
+        text = (e.read().decode("utf-8", errors="replace") if hasattr(e, "read") else "")
+        raise OpenHeiTeacherError(f"OpenHei API error: {e.code} {text[:500]}") from e
+    except URLError as e:
+        raise OpenHeiTeacherError(f"OpenHei API request failed: {e.reason}") from e
+    except TimeoutError as e:
+        raise OpenHeiTeacherError(f"OpenHei API request timed out: {url}") from e
+
+    try:
+        return json.loads(text) if text else {}
+    except json.JSONDecodeError as e:
+        raise OpenHeiTeacherError(f"OpenHei API returned non-JSON: {text[:500]}") from e
+
+
+def _http_stream(method: str, url: str, *, timeout_sec: float):
+    req = Request(url, method=method)
+    req.add_header("Accept", "text/event-stream")
+    try:
+        return urlopen(req, timeout=timeout_sec)  # nosec - URL comes from env
+    except HTTPError as e:
+        text = (e.read().decode("utf-8", errors="replace") if hasattr(e, "read") else "")
+        raise OpenHeiTeacherError(f"OpenHei API error: {e.code} {text[:500]}") from e
+    except URLError as e:
+        raise OpenHeiTeacherError(f"OpenHei API request failed: {e.reason}") from e
+    except TimeoutError as e:
+        raise OpenHeiTeacherError(f"OpenHei API request timed out: {url}") from e
+
+
+def _iter_sse_data_messages(lines: Iterable[bytes]) -> Iterable[str]:
+    """Yield SSE `data:` payloads (joined by \n) per event."""
+
+    data_lines: List[str] = []
+    for raw in lines:
+        try:
+            line = raw.decode("utf-8", errors="replace")
+        except Exception:
+            line = str(raw)
+        line = line.rstrip("\r\n")
+
+        # Blank line delimits an event.
+        if line == "":
+            if data_lines:
+                yield "\n".join(data_lines)
+                data_lines = []
+            continue
+
+        if line.startswith(":"):
+            # Comment / keepalive.
+            continue
+        if line.startswith("data:"):
+            data_lines.append(line[5:].lstrip())
+            continue
+
+        # Ignore other SSE fields: event:, id:, retry:
+
+    if data_lines:
+        yield "\n".join(data_lines)
+
+
+def _iter_sse_json_events(lines: Iterable[bytes]) -> Iterable[Dict[str, Any]]:
+    for payload in _iter_sse_data_messages(lines):
+        payload = payload.strip()
+        if not payload:
+            continue
+        try:
+            event = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict):
+            yield event
+
+
+def _format_openhei_error(err: Any) -> str:
+    if isinstance(err, dict):
+        # Common patterns include {type, message} or {code, message}.
+        msg = err.get("message") or err.get("error") or ""
+        if isinstance(msg, str) and msg.strip():
+            return redact_secrets(msg.strip())
+    return redact_secrets(json.dumps(err, ensure_ascii=False)[:2000])
+
+
+class _AssistantTextCollector:
+    def __init__(self, *, session_id: str, message_id: Optional[str] = None) -> None:
+        self.session_id = session_id
+        self.message_id = message_id
+        self._part_order: List[str] = []
+        self._text_by_part: Dict[str, str] = {}
+        self._completed = False
+        self._last_relevant_t = time.monotonic()
+        self._error: Optional[str] = None
+
+    @property
+    def completed(self) -> bool:
+        return self._completed
+
+    @property
+    def last_relevant_t(self) -> float:
+        return self._last_relevant_t
+
+    @property
+    def error(self) -> Optional[str]:
+        return self._error
+
+    def _set_message_id_if_needed(self, message_id: Optional[str]) -> None:
+        if self.message_id or not message_id:
+            return
+        self.message_id = message_id
+
+    def feed(self, event: Dict[str, Any]) -> None:
+        et = event.get("type")
+        # OpenHei event shapes vary between transports/versions. Newer SSE events
+        # carry a `properties` object. Older/alternate shapes may put fields at
+        # the top-level. Accept both by normalizing `props` to a dict view of
+        # event properties.
+        props = event.get("properties")
+        if not isinstance(props, dict):
+            # Fallback to using the event dict itself (excluding `type`). This
+            # keeps compatibility with non-wrapped events that include sessionID,
+            # messageID, part, info, etc. as top-level keys.
+            props = {k: v for k, v in event.items() if k != "type"}
+
+        if et in {"session.status", "session.idle"}:
+            sess = props.get("sessionID")
+            if sess == self.session_id:
+                # Keep-alive progress; useful when providers are rate-limiting.
+                self._last_relevant_t = time.monotonic()
+                status = props.get("status")
+                if et == "session.status" and isinstance(status, dict) and status.get("type") == "retry":
+                    msg = status.get("message")
+                    if isinstance(msg, str) and _is_retryable_error(msg):
+                        self._error = redact_secrets(msg.strip())
+            return
+
+        if et == "session.error":
+            sess = props.get("sessionID")
+            if sess == self.session_id:
+                self._error = _format_openhei_error(props.get("error"))
+            return
+
+        if et == "message.updated":
+            # `info` may be nested or at top-level depending on server version.
+            info = props.get("info") if isinstance(props.get("info"), dict) else event.get("info") or props
+            if not isinstance(info, dict):
+                return
+            if info.get("sessionID") != self.session_id:
+                return
+            if info.get("role") != "assistant":
+                return
+            mid = info.get("id")
+            if isinstance(mid, str) and mid:
+                self._set_message_id_if_needed(mid)
+            if self.message_id and mid != self.message_id:
+                return
+
+            self._last_relevant_t = time.monotonic()
+            time_obj = info.get("time")
+            if isinstance(time_obj, dict) and time_obj.get("completed") is not None:
+                self._completed = True
+            return
+
+        if et == "message.part.delta":
+            # support both nested `properties` and flat event shapes
+            sess = props.get("sessionID")
+            if sess != self.session_id:
+                return
+            mid = props.get("messageID")
+            if isinstance(mid, str) and mid:
+                self._set_message_id_if_needed(mid)
+            if self.message_id and mid != self.message_id:
+                return
+            if props.get("field") != "text":
+                return
+
+            part_id = props.get("partID")
+            delta = props.get("delta")
+            if not isinstance(part_id, str) or not part_id:
+                return
+            if not isinstance(delta, str) or not delta:
+                return
+            if part_id not in self._text_by_part:
+                self._part_order.append(part_id)
+                self._text_by_part[part_id] = ""
+            self._text_by_part[part_id] += delta
+            self._last_relevant_t = time.monotonic()
+            return
+
+        if et == "message.part.updated":
+            # `part` may be nested or provided at top-level.
+            part = props.get("part") if isinstance(props.get("part"), dict) else event.get("part") or props
+            if not isinstance(part, dict):
+                return
+            if part.get("sessionID") != self.session_id:
+                return
+            mid = part.get("messageID")
+            if isinstance(mid, str) and mid:
+                self._set_message_id_if_needed(mid)
+            if self.message_id and mid != self.message_id:
+                return
+
+            ptype = part.get("type")
+            part_id = part.get("id")
+            if not isinstance(part_id, str) or not part_id:
+                return
+
+            if ptype == "text":
+                text = part.get("text")
+                if isinstance(text, str):
+                    if part_id not in self._text_by_part:
+                        self._part_order.append(part_id)
+                    self._text_by_part[part_id] = text
+                    self._last_relevant_t = time.monotonic()
+                time_obj = part.get("time")
+                if isinstance(time_obj, dict) and time_obj.get("end") is not None:
+                    self._completed = True
+                return
+
+            if ptype == "step-finish":
+                self._last_relevant_t = time.monotonic()
+                self._completed = True
+                return
+
+    def text(self) -> str:
+        if not self._part_order:
+            return ""
+        return "".join(self._text_by_part.get(pid, "") for pid in self._part_order).strip()
+
+
+def _api_run_once(
+    *,
+    attach_url: str,
+    repo_dir: str,
+    prompt: str,
+    model_id: str,
+    agent: str,
+    timeout_sec: float,
+) -> str:
+    if "/" not in model_id:
+        raise OpenHeiTeacherError(f"Invalid model id (expected provider/model): {model_id!r}")
+    provider_id, model_name = model_id.split("/", 1)
+
+    session = _http_json(
+        "POST",
+        _api_url(attach_url, f"/session?directory={quote(repo_dir)}"),
+        {"title": "heidi-engine teacher"},
+        timeout_sec=min(10.0, timeout_sec),
+    )
+    session_id = session.get("id")
+    if not isinstance(session_id, str) or not session_id:
+        raise OpenHeiTeacherError("OpenHei API did not return a session id")
+
+    msg_id = f"msg_heidi_{int(time.time()*1000)}_{os.getpid()}"
+
+    # Subscribe to the directory event stream and reconstruct assistant output.
+    # This avoids relying on the non-streaming message list (which can lag or omit parts).
+    stream_url = _api_url(attach_url, f"/event?directory={quote(repo_dir)}")
+    collector = _AssistantTextCollector(session_id=session_id)
+
+    # Use a short socket timeout so we can enforce inactivity/overall timeouts.
+    overall_deadline = time.monotonic() + float(timeout_sec)
+    inactivity_timeout = min(30.0, max(5.0, float(timeout_sec) / 10.0))
+
+    message_sent = False
+    read_timeout = min(60.0, max(5.0, float(timeout_sec) / 5.0))
+
+    while True:
+        now = time.monotonic()
+        if now >= overall_deadline:
+            raise OpenHeiTeacherError("OpenHei SSE timed out waiting for assistant output")
+        if collector.error:
+            raise OpenHeiTeacherError(f"OpenHei SSE error: {collector.error}")
+        if collector.message_id and (now - collector.last_relevant_t) > inactivity_timeout:
+            raise OpenHeiTeacherError("OpenHei SSE inactive while waiting for completion")
+
+        with _http_stream("GET", stream_url, timeout_sec=read_timeout) as resp:
+            if not message_sent:
+                # Send message after stream is connected to avoid missing early deltas.
+                # Include directory query parameter for API parity with OpenHei clients.
+                _http_json(
+                    "POST",
+                    _api_url(attach_url, f"/session/{quote(session_id)}/message?directory={quote(repo_dir)}"),
+                    {
+                        "messageID": msg_id,
+                        "model": {"providerID": provider_id, "modelID": model_name},
+                        "agent": agent or "",
+                        "parts": [{"type": "text", "text": prompt}],
+                    },
+                    timeout_sec=timeout_sec,
+                )
+                message_sent = True
+
+            try:
+                for event in _iter_sse_json_events(resp):
+                    collector.feed(event)
+                    if collector.error:
+                        raise OpenHeiTeacherError(f"OpenHei SSE error: {collector.error}")
+                    if collector.completed:
+                        text = collector.text()
+                        if not text:
+                            raise OpenHeiTeacherError("OpenHei SSE contained no completed assistant text")
+                        return text
+                    if time.monotonic() >= overall_deadline:
+                        raise OpenHeiTeacherError("OpenHei SSE timed out waiting for assistant output")
+            except (socket.timeout, OSError) as e:
+                # urllib/httpclient can raise OSError("cannot read from timed out object") after a timeout.
+                msg = str(e).lower()
+                if "timed out" in msg or "timeout" in msg:
+                    continue
+                raise
+
+
 @dataclass
 class OpenHeiTeacher:
     name: str = "openhei"
@@ -154,6 +510,38 @@ class OpenHeiTeacher:
         if attach_url:
             validate_openhei_attach_url(attach_url)
 
+        # Prefer HTTP attach API when available (no need for openhei CLI).
+        use_http = attach_url and _bool_env("OPENHEI_ATTACH_HTTP", "1")
+        if use_http and attach_url:
+            last_err: Optional[str] = None
+            for attempt in range(self.retries + 1):
+                try:
+                    return _api_run_once(
+                        attach_url=attach_url,
+                        repo_dir=repo_dir,
+                        prompt=prompt,
+                        model_id=model_id,
+                        agent=agent,
+                        timeout_sec=float(self.timeout_sec),
+                    )
+                except OpenHeiTeacherError as e:
+                    last_err = str(e)
+                    if strict_attach:
+                        raise
+                    # Stale attach contexts should be retried once, then fall back to non-attach mode.
+                    if _contains_session_not_found(last_err):
+                        if attempt == 0:
+                            continue
+                        break
+                    if attempt < self.retries and _is_retryable_error(last_err):
+                        _sleep_backoff(self.retry_backoff_sec, attempt)
+                        continue
+                    raise
+
+            # Non-strict attach fallback: try non-attach mode (CLI) after a stale session.
+            # This matches the attach semantics even if the environment lacks the CLI.
+            use_http = False
+
         # OpenHei Path-B: prompt is provided via stdin (no --prompt flag).
         stdin_text = prompt if prompt.endswith("\n") else (prompt + "\n")
 
@@ -161,9 +549,17 @@ class OpenHeiTeacher:
         env.setdefault("NO_COLOR", "1")
         env.setdefault("OPENHEI_NO_TUI", "1")
 
+        cli_raw = (os.environ.get("OPENHEI_CLI") or "openhei").strip() or "openhei"
+        try:
+            cli_parts = shlex.split(cli_raw)
+        except ValueError:
+            cli_parts = ["openhei"]
+        if not cli_parts:
+            cli_parts = ["openhei"]
+
         def build_cmd(maybe_attach: Optional[str]) -> list[str]:
             cmd = [
-                "openhei",
+                *cli_parts,
                 "run",
                 "--format",
                 "json",
@@ -199,7 +595,7 @@ class OpenHeiTeacher:
                 except subprocess.TimeoutExpired as e:
                     last_err = f"openhei timeout after {self.timeout_sec}s"
                     if attempt < retries:
-                        time.sleep(self.retry_backoff_sec * (attempt + 1))
+                        _sleep_backoff(self.retry_backoff_sec, attempt)
                         continue
                     raise OpenHeiTeacherError(last_err) from e
 
@@ -217,7 +613,10 @@ class OpenHeiTeacher:
                     if _contains_session_not_found(last_err):
                         raise OpenHeiTeacherError(last_err)
                     if attempt < retries:
-                        time.sleep(self.retry_backoff_sec * (attempt + 1))
+                        if _is_retryable_error(last_err):
+                            _sleep_backoff(self.retry_backoff_sec, attempt)
+                        else:
+                            _sleep_backoff(self.retry_backoff_sec / 2.0, attempt)
                         continue
                     raise OpenHeiTeacherError(last_err)
 
@@ -228,7 +627,10 @@ class OpenHeiTeacher:
                     if _contains_session_not_found(last_err):
                         raise
                     if attempt < retries:
-                        time.sleep(self.retry_backoff_sec * (attempt + 1))
+                        if _is_retryable_error(last_err):
+                            _sleep_backoff(self.retry_backoff_sec, attempt)
+                        else:
+                            _sleep_backoff(self.retry_backoff_sec / 2.0, attempt)
                         continue
                     raise
 

--- a/scripts/01_teacher_generate.py
+++ b/scripts/01_teacher_generate.py
@@ -16,14 +16,16 @@ Backends:
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import json
 import os
 import random
+import statistics
 import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 
 
 def _ensure_repo_root_on_sys_path() -> None:
@@ -92,6 +94,18 @@ def parse_args() -> argparse.Namespace:
         help="Repo dir passed to OpenHei (--dir). Defaults to OUT_DIR.",
     )
     p.add_argument("--seed", type=int, default=int(os.environ.get("SEED", "42")))
+    p.add_argument(
+        "--workers",
+        type=int,
+        default=int(os.environ.get("TEACHER_WORKERS", "1")),
+        help="Number of in-process worker threads (OpenAI teacher is network-bound)",
+    )
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=int(os.environ.get("TEACHER_BATCH_SIZE", "1")),
+        help="Number of samples per teacher request (reduces overhead)",
+    )
     return p.parse_args()
 
 
@@ -100,12 +114,33 @@ def build_prompt(template: Dict[str, str], code: str, language: str) -> str:
 
 
 def build_openhei_request(*, instruction: str, input_text: str) -> str:
+    max_tokens = int(os.environ.get("TEACHER_MAX_TOKENS", "256"))
     return (
         "Return ONLY strict JSON (no markdown) with keys instruction,input,output.\n"
         "instruction must exactly match the provided instruction.\n"
         "input must exactly match the provided input.\n\n"
+        f"Constraints: output must be concise and <= {max_tokens} tokens.\n\n"
         f"instruction: {instruction}\n\n"
         f"input: {input_text}\n"
+    )
+
+
+def build_openhei_batch_request(*, items: List[Tuple[str, str, str]]) -> str:
+    """Build a single prompt that asks for a JSON array of (id,instruction,input,output)."""
+    max_tokens = int(os.environ.get("TEACHER_MAX_TOKENS", "256"))
+    lines: List[str] = []
+    for sid, instruction, input_text in items:
+        lines.append(f"id: {sid}\ninstruction: {instruction}\ninput: {input_text}")
+    joined = "\n\n---\n\n".join(lines)
+    return (
+        "Return ONLY strict JSON (no markdown).\n"
+        "Output must be a JSON array where each element has keys id,instruction,input,output.\n"
+        "id must exactly match the provided id.\n"
+        "instruction must exactly match the provided instruction.\n"
+        "input must exactly match the provided input.\n"
+        f"Constraints: each output must be concise and <= {max_tokens} tokens.\n\n"
+        + joined
+        + "\n"
     )
 
 
@@ -113,72 +148,189 @@ def legacy_synthetic_output(instruction: str, input_text: str) -> str:
     return f"{instruction}\n\n{input_text}\n\n# (synthetic legacy backend)"
 
 
-def generate_one(
-    *,
-    idx: int,
-    round_num: int,
-    backend: str,
-    teacher_model: str,
-    language: str,
-    repo_dir: str,
-) -> Dict[str, Any]:
-    template = random.choice(PROMPT_TEMPLATES)
-    code = random.choice(SYNTHETIC_CODE_SAMPLES)
-    instruction = template["instruction"]
-    input_text = build_prompt(template, code, language)
+class SampleSpec:
+    __slots__ = (
+        "idx",
+        "round_num",
+        "teacher_model",
+        "backend",
+        "task_type",
+        "instruction",
+        "input_text",
+    )
 
-    if backend == "openhei":
-        _ensure_repo_root_on_sys_path()
-        if not repo_dir:
-            raise SystemExit("TEACHER_BACKEND=openhei requires --repo-dir (or OUT_DIR)")
-        if "/" not in teacher_model:
-            raise SystemExit(
-                "TEACHER_BACKEND=openhei requires TEACHER_MODEL like 'provider/model' "
-                f"(got {teacher_model!r})"
-            )
+    def __init__(
+        self,
+        *,
+        idx: int,
+        round_num: int,
+        teacher_model: str,
+        backend: str,
+        task_type: str,
+        instruction: str,
+        input_text: str,
+    ) -> None:
+        self.idx = idx
+        self.round_num = round_num
+        self.teacher_model = teacher_model
+        self.backend = backend
+        self.task_type = task_type
+        self.instruction = instruction
+        self.input_text = input_text
 
-        from heidi_engine.teacher.base import TeacherRegistry
 
-        teacher = TeacherRegistry.from_env().get("openhei")
-        prompt = build_openhei_request(instruction=instruction, input_text=input_text)
-        assistant_text = teacher.run(
-            repo_dir=repo_dir,
-            prompt=prompt,
-            model_id=teacher_model,
-            agent=os.environ.get("OPENHEI_AGENT", ""),
-            attach_url=os.environ.get("OPENHEI_ATTACH") or None,
-        )
+def _truncate(text: str, max_chars: int) -> str:
+    if max_chars <= 0:
+        return text
+    if len(text) <= max_chars:
+        return text
+    return text[: max(0, max_chars - 1)] + "…"
 
-        try:
-            payload = json.loads(assistant_text)
-        except json.JSONDecodeError as e:
-            raise RuntimeError(f"OpenHei teacher output was not valid JSON: {e}")
 
-        for key in ("instruction", "input", "output"):
-            if key not in payload or not isinstance(payload[key], str):
-                raise RuntimeError(f"OpenHei teacher output missing/invalid key: {key}")
+def _cap_output(text: str) -> str:
+    # Hard-ish cap to keep runaway generations from exploding dataset size.
+    max_tokens = int(os.environ.get("TEACHER_MAX_TOKENS", "256"))
+    max_chars = int(os.environ.get("TEACHER_MAX_OUTPUT_CHARS", str(max(512, max_tokens * 8))))
+    return _truncate(text, max_chars)
 
-        instruction_out = payload["instruction"]
-        input_out = payload["input"]
-        output_out = payload["output"]
-    else:
-        instruction_out = instruction
-        input_out = input_text
-        output_out = legacy_synthetic_output(instruction, input_text)
 
+def _pctl(values: List[float], p: float) -> float:
+    if not values:
+        return 0.0
+    s = sorted(values)
+    k = int(round((len(s) - 1) * p))
+    return float(s[max(0, min(len(s) - 1, k))])
+
+
+def _now() -> float:
+    return time.monotonic()
+
+
+def _row_from_spec(spec: SampleSpec, *, instruction_out: str, input_out: str, output_out: str) -> Dict[str, Any]:
     return {
-        "id": f"round_{round_num}_{idx:04d}",
+        "id": f"round_{spec.round_num}_{spec.idx:04d}",
         "instruction": instruction_out,
         "input": input_out,
         "output": output_out,
         "metadata": {
-            "task_type": template["task_type"],
-            "round": round_num,
+            "task_type": spec.task_type,
+            "round": spec.round_num,
             "timestamp": _utc_now_z(),
-            "teacher_model": teacher_model,
-            "teacher_backend": backend,
+            "teacher_model": spec.teacher_model,
+            "teacher_backend": spec.backend,
         },
     }
+
+
+def _generate_specs(*, samples: int, seed: int, round_num: int, backend: str, teacher_model: str, language: str) -> List[SampleSpec]:
+    rng = random.Random(seed)
+    specs: List[SampleSpec] = []
+    max_prompt_chars = int(os.environ.get("TEACHER_MAX_PROMPT_CHARS", "6000"))
+    for idx in range(samples):
+        template = rng.choice(PROMPT_TEMPLATES)
+        code = rng.choice(SYNTHETIC_CODE_SAMPLES)
+        instruction = template["instruction"]
+        input_text = build_prompt(template, code, language)
+        input_text = _truncate(input_text, max_prompt_chars)
+        specs.append(
+            SampleSpec(
+                idx=idx,
+                round_num=round_num,
+                teacher_model=teacher_model,
+                backend=backend,
+                task_type=template["task_type"],
+                instruction=instruction,
+                input_text=input_text,
+            )
+        )
+    return specs
+
+
+def _openhei_call_batch(
+    *,
+    teacher: Any,
+    repo_dir: str,
+    model_id: str,
+    agent: str,
+    attach_url: Optional[str],
+    batch: List[SampleSpec],
+) -> Tuple[List[Dict[str, Any]], float, int, int]:
+    """Return (rows, latency_sec, prompt_chars, output_chars)."""
+    sid_items = [(f"round_{s.round_num}_{s.idx:04d}", s.instruction, s.input_text) for s in batch]
+    prompt = build_openhei_batch_request(items=sid_items) if len(batch) > 1 else build_openhei_request(
+        instruction=batch[0].instruction,
+        input_text=batch[0].input_text,
+    )
+
+    t0 = _now()
+    assistant_text = teacher.run(
+        repo_dir=repo_dir,
+        prompt=prompt,
+        model_id=model_id,
+        agent=agent,
+        attach_url=attach_url,
+    )
+    dt = _now() - t0
+
+    prompt_chars = len(prompt)
+    output_chars = len(assistant_text or "")
+
+    try:
+        payload = json.loads(assistant_text)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"OpenHei teacher output was not valid JSON: {e}")
+
+    if len(batch) == 1:
+        if not isinstance(payload, dict):
+            raise RuntimeError("OpenHei teacher output was not a JSON object")
+        for key in ("instruction", "input", "output"):
+            if key not in payload or not isinstance(payload[key], str):
+                raise RuntimeError(f"OpenHei teacher output missing/invalid key: {key}")
+        s = batch[0]
+        return (
+            [
+                _row_from_spec(
+                    s,
+                    instruction_out=payload["instruction"],
+                    input_out=payload["input"],
+                    output_out=_cap_output(payload["output"]),
+                )
+            ],
+            dt,
+            prompt_chars,
+            output_chars,
+        )
+
+    if not isinstance(payload, list):
+        raise RuntimeError("OpenHei teacher output was not a JSON array")
+
+    by_id: Dict[str, Dict[str, Any]] = {}
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        if not isinstance(item.get("id"), str):
+            continue
+        by_id[item["id"]] = item
+
+    rows: List[Dict[str, Any]] = []
+    for s in batch:
+        sid = f"round_{s.round_num}_{s.idx:04d}"
+        item = by_id.get(sid)
+        if not item:
+            raise RuntimeError(f"OpenHei teacher output missing id: {sid}")
+        for key in ("instruction", "input", "output"):
+            if key not in item or not isinstance(item[key], str):
+                raise RuntimeError(f"OpenHei teacher output missing/invalid key for {sid}: {key}")
+        rows.append(
+            _row_from_spec(
+                s,
+                instruction_out=item["instruction"],
+                input_out=item["input"],
+                output_out=_cap_output(item["output"]),
+            )
+        )
+
+    return (rows, dt, prompt_chars, output_chars)
 
 
 def write_jsonl(path: str, rows: List[Dict[str, Any]]) -> None:
@@ -248,58 +400,133 @@ def main() -> int:
             progress_task_id = None
             use_rich = False
 
-    rows: List[Dict[str, Any]] = []
+    specs = _generate_specs(
+        samples=args.samples,
+        seed=args.seed,
+        round_num=args.round,
+        backend=args.backend,
+        teacher_model=args.teacher,
+        language=args.language,
+    )
+    rows_by_idx: Dict[int, Dict[str, Any]] = {}
 
-    start = time.monotonic()
+    start = _now()
 
-    if use_rich and progress is not None:
-        with progress:
-            for i in range(args.samples):
-                rows.append(
-                    generate_one(
-                        idx=i,
-                        round_num=args.round,
-                        backend=args.backend,
-                        teacher_model=args.teacher,
-                        language=args.language,
-                        repo_dir=args.repo_dir,
-                    )
-                )
-                progress.update(progress_task_id, advance=1)
-                if verbose and (i + 1) % 10 == 0:
-                    print(f"[INFO] Generated {i + 1}/{args.samples}", file=sys.stderr)
+    # Performance knobs
+    workers = max(1, int(args.workers or 1))
+    batch_size = max(1, int(args.batch_size or 1))
+    if args.backend != "openhei":
+        workers = 1
+        batch_size = 1
+
+    if backend == "legacy":
+        for s in specs:
+            rows_by_idx[s.idx] = _row_from_spec(
+                s,
+                instruction_out=s.instruction,
+                input_out=s.input_text,
+                output_out=legacy_synthetic_output(s.instruction, s.input_text),
+            )
+        # Keep the progress line contract.
+        print(f"[INFO] Generated {args.samples}/{args.samples} (100%) | 0.00 it/s | ETA 0s", file=sys.stderr)
     else:
-        # Non-TTY / no-rich fallback: periodic, non-ANSI status lines.
-        last_print_t = 0.0
-        for i in range(args.samples):
-            rows.append(
-                generate_one(
-                    idx=i,
-                    round_num=args.round,
-                    backend=args.backend,
-                    teacher_model=args.teacher,
-                    language=args.language,
-                    repo_dir=args.repo_dir,
-                )
+        _ensure_repo_root_on_sys_path()
+        if not args.repo_dir:
+            raise SystemExit("TEACHER_BACKEND=openhei requires --repo-dir (or OUT_DIR)")
+        if "/" not in args.teacher:
+            raise SystemExit(
+                "TEACHER_BACKEND=openhei requires TEACHER_MODEL like 'provider/model' " f"(got {args.teacher!r})"
             )
 
-            now = time.monotonic()
-            should_print = verbose or ((i + 1) % 10 == 0) or (now - last_print_t >= 15.0)
-            if should_print:
-                elapsed = max(1e-6, now - start)
-                done = i + 1
-                rate = done / elapsed
-                remaining = args.samples - done
-                eta = int(remaining / rate) if rate > 0 else 0
-                pct = (done / args.samples * 100.0) if args.samples else 100.0
-                print(
-                    f"[INFO] Generated {done}/{args.samples} ({pct:.0f}%) | {rate:.2f} it/s | ETA {eta}s",
-                    file=sys.stderr,
-                )
-                last_print_t = now
+        from heidi_engine.teacher.base import TeacherRegistry
 
-    write_jsonl(args.output, rows)
-    print(f"[OK] Wrote {len(rows)} samples to {args.output}", file=sys.stderr)
+        teacher = TeacherRegistry.from_env().get("openhei")
+        agent = os.environ.get("OPENHEI_AGENT", "")
+        attach_url = os.environ.get("OPENHEI_ATTACH") or None
+
+        # Split into batches to reduce overhead.
+        batches: List[List[SampleSpec]] = [specs[i : i + batch_size] for i in range(0, len(specs), batch_size)]
+
+        done = 0
+        last_print_t = 0.0
+        latencies: List[float] = []
+        prompt_chars: List[int] = []
+        output_chars: List[int] = []
+        errors = 0
+
+        def worker(batch: List[SampleSpec]) -> Tuple[List[Dict[str, Any]], float, int, int]:
+            return _openhei_call_batch(
+                teacher=teacher,
+                repo_dir=args.repo_dir,
+                model_id=args.teacher,
+                agent=agent,
+                attach_url=attach_url,
+                batch=batch,
+            )
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as ex:
+            futs = [ex.submit(worker, b) for b in batches]
+
+            if use_rich and progress is not None:
+                with progress:
+                    for fut in concurrent.futures.as_completed(futs):
+                        batch_rows, dt_s, pchars, ochars = fut.result()
+                        for r in batch_rows:
+                            idx = int(str(r["id"]).split("_")[-1])  # round_X_0001 -> 0001
+                            rows_by_idx[idx] = r
+                        done = len(rows_by_idx)
+                        latencies.append(dt_s)
+                        prompt_chars.append(pchars)
+                        output_chars.append(ochars)
+                        progress.update(progress_task_id, completed=done)
+            else:
+                for fut in concurrent.futures.as_completed(futs):
+                    try:
+                        batch_rows, dt_s, pchars, ochars = fut.result()
+                    except Exception as e:
+                        errors += 1
+                        raise
+                    for r in batch_rows:
+                        idx = int(str(r["id"]).split("_")[-1])
+                        rows_by_idx[idx] = r
+                    done = len(rows_by_idx)
+                    latencies.append(dt_s)
+                    prompt_chars.append(pchars)
+                    output_chars.append(ochars)
+
+                    now = _now()
+                    should_print = verbose or (done % 10 == 0) or (now - last_print_t >= 15.0) or done == args.samples
+                    if should_print:
+                        elapsed = max(1e-6, now - start)
+                        rate = done / elapsed
+                        remaining = args.samples - done
+                        eta = int(remaining / rate) if rate > 0 else 0
+                        pct = (done / args.samples * 100.0) if args.samples else 100.0
+                        print(
+                            f"[INFO] Generated {done}/{args.samples} ({pct:.0f}%) | {rate:.2f} it/s | ETA {eta}s",
+                            file=sys.stderr,
+                        )
+
+                        # Metrics line (optional, phone-friendly)
+                        if latencies:
+                            avg = statistics.mean(latencies)
+                            p50 = _pctl(latencies, 0.50)
+                            p95 = _pctl(latencies, 0.95)
+                            avg_out = int(statistics.mean(output_chars)) if output_chars else 0
+                            approx_tokens = avg_out // 4
+                            print(
+                                f"[METRIC] workers={workers} batch={batch_size} avg={avg:.2f}s p50={p50:.2f}s p95={p95:.2f}s out~{approx_tokens}tok err={errors}",
+                                file=sys.stderr,
+                            )
+                        last_print_t = now
+
+        # Ensure final progress line exists for SSE parsers.
+        if done != args.samples:
+            print(f"[INFO] Generated {done}/{args.samples} ({(done/args.samples*100.0):.0f}%) | 0.00 it/s | ETA 0s", file=sys.stderr)
+
+    ordered = [rows_by_idx[i] for i in range(args.samples)]
+    write_jsonl(args.output, ordered)
+    print(f"[OK] Wrote {len(ordered)} samples to {args.output}", file=sys.stderr)
     return 0
 
 

--- a/tests/test_openhei_teacher_parse.py
+++ b/tests/test_openhei_teacher_parse.py
@@ -63,6 +63,9 @@ def test_openhei_teacher_sends_prompt_via_stdin(monkeypatch, tmp_path):
 def test_openhei_teacher_falls_back_when_attach_session_not_found(monkeypatch, tmp_path, capsys):
     from heidi_engine.teacher import openhei_teacher as mod
 
+    # Force legacy CLI attach path for this unit test.
+    monkeypatch.setenv("OPENHEI_ATTACH_HTTP", "0")
+
     # Avoid real network validation in unit tests.
     monkeypatch.setattr(mod, "validate_openhei_attach_url", lambda *_a, **_k: None)
 
@@ -113,6 +116,7 @@ def test_openhei_teacher_strict_attach_fails_closed_on_session_not_found(monkeyp
     from heidi_engine.teacher import openhei_teacher as mod
 
     monkeypatch.setenv("OPENHEI_ATTACH_STRICT", "1")
+    monkeypatch.setenv("OPENHEI_ATTACH_HTTP", "0")
     monkeypatch.setattr(mod, "validate_openhei_attach_url", lambda *_a, **_k: None)
 
     class R:

--- a/tests/test_openhei_teacher_sse.py
+++ b/tests/test_openhei_teacher_sse.py
@@ -1,0 +1,84 @@
+from heidi_engine.teacher.openhei_teacher import _AssistantTextCollector
+
+
+def test_assistant_text_collector_nested_props_completion():
+    c = _AssistantTextCollector(session_id="sess1")
+
+    # Simulate streamed delta events (nested `properties` shape)
+    c.feed({
+        "type": "message.part.delta",
+        "properties": {
+            "sessionID": "sess1",
+            "messageID": "mid1",
+            "partID": "p1",
+            "field": "text",
+            "delta": "Hello ",
+        },
+    })
+
+    c.feed({
+        "type": "message.part.delta",
+        "properties": {
+            "sessionID": "sess1",
+            "messageID": "mid1",
+            "partID": "p1",
+            "field": "text",
+            "delta": "world",
+        },
+    })
+
+    # Finalize via message.part.updated with time.end
+    c.feed({
+        "type": "message.part.updated",
+        "properties": {
+            "part": {
+                "id": "p1",
+                "sessionID": "sess1",
+                "messageID": "mid1",
+                "type": "text",
+                "text": "Hello world",
+                "time": {"end": "t"},
+            }
+        },
+    })
+
+    assert c.completed
+    assert c.text() == "Hello world"
+
+
+def test_assistant_text_collector_flat_event_shape():
+    c = _AssistantTextCollector(session_id="sess2")
+
+    # Simulate events using a flat/top-level event shape (no `properties`)
+    c.feed({
+        "type": "message.part.delta",
+        "sessionID": "sess2",
+        "messageID": "mid2",
+        "partID": "p2",
+        "field": "text",
+        "delta": "A",
+    })
+
+    c.feed({
+        "type": "message.part.delta",
+        "sessionID": "sess2",
+        "messageID": "mid2",
+        "partID": "p2",
+        "field": "text",
+        "delta": "B",
+    })
+
+    c.feed({
+        "type": "message.part.updated",
+        "part": {
+            "id": "p2",
+            "sessionID": "sess2",
+            "messageID": "mid2",
+            "type": "text",
+            "text": "AB",
+            "time": {"end": "t"},
+        },
+    })
+
+    assert c.completed
+    assert c.text() == "AB"


### PR DESCRIPTION
Use OpenHei SSE stream reliably by accepting both 'properties'-wrapped events and flat/top-level event shapes. This makes HTTP attach reconstruct assistant text without depending on openhei CLI. Added unit tests for SSE assembly.\n\nFiles changed:\n- heidi_engine/teacher/openhei_teacher.py\n- tests/test_openhei_teacher_sse.py\n\nNo behavior changes to non-attach CLI fallback; attach retry/backoff/fallback rules retained.