### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal vulnerability in telemetry

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Security Journal
+
+## 2024-05-22 - Path Traversal in Telemetry Run ID
+**Vulnerability:** The `get_run_dir` function in `heidi_engine/telemetry.py` used the `run_id` directly to construct a file path without sanitization, allowing for arbitrary directory creation and potential file hijacking via malicious `run_id` values (e.g., `../../etc`).
+**Learning:** Using `Path(run_id)` or string concatenation with user-provided identifiers can lead to path traversal if the identifier contains relative (`..`) or absolute (`/`) path components.
+**Prevention:** Always sanitize user-provided identifiers by using `Path(id).name` to extract only the filename component and provide a safe fallback for empty or reserved names (like `.` or `..`). Implement defense-in-depth by verifying that resolved paths remain within the intended parent directory.

--- a/heidi_engine/dashboard.py
+++ b/heidi_engine/dashboard.py
@@ -1227,7 +1227,7 @@ def main():
         If no run specified, shows interactive selection
     """
     global run_id, current_view
-    
+
     parser = argparse.ArgumentParser(
         prog="heidi-engine dashboard",
         description="Heidi Engine Real-Time Dashboard"

--- a/heidi_engine/telemetry.py
+++ b/heidi_engine/telemetry.py
@@ -352,18 +352,26 @@ def get_default_usage() -> Dict[str, Any]:
 
 def get_run_dir(run_id: Optional[str] = None) -> Path:
     """
-    Get the run directory path.
+    Get the run directory path with path traversal protection.
 
     HOW IT WORKS:
         Creates runs/<run_id>/ directory structure.
         All run-specific files go here.
 
-    TUNABLE:
-        - Modify directory structure by changing path construction
+    SECURITY:
+        - Prevents path traversal by using Path(run_id).name
+        - Blocks '.', '..', and empty strings (falls back to 'default_run')
     """
     if run_id is None:
         run_id = get_run_id()
-    return Path(AUTOTRAIN_DIR) / "runs" / run_id
+
+    # SECURITY: Prevent path traversal by only using the filename part
+    # and blocking relative/absolute paths.
+    safe_run_id = Path(run_id).name
+    if safe_run_id in (".", "..") or not safe_run_id:
+        safe_run_id = "default_run"
+
+    return Path(AUTOTRAIN_DIR) / "runs" / safe_run_id
 
 
 def get_events_path(run_id: Optional[str] = None) -> Path:
@@ -656,7 +664,7 @@ def get_state(run_id: Optional[str] = None) -> Dict[str, Any]:
     HOW IT WORKS:
         - Reads state.json file
         - Returns empty state if file doesn't exist
-    
+
     ARGS:
         run_id: Run to read (defaults to current run)
 
@@ -687,44 +695,44 @@ def get_state(run_id: Optional[str] = None) -> Dict[str, Any]:
 def resolve_status(state: Dict[str, Any]) -> str:
     """
     Resolve run status from on-disk metadata.
-    
+
     STATUS VALUES:
         - idle: No active run, or run_id present but no events
         - running: Worker active / stop not requested / still processing
         - stopped: stop_requested=true or pipeline complete
         - error: last_error present or health degraded
-    
+
     HOW IT WORKS:
         - Checks stop_requested flag
         - Checks status field
         - Checks for error indicators
-    
+
     ARGS:
         state: State dictionary from state.json
-    
+
     RETURNS:
         Status string: idle, running, stopped, error
     """
     # Explicit stop requested
     if state.get("stop_requested", False):
         return "stopped"
-    
+
     # Check explicit status first
     status = state.get("status", "")
     if status in ("running", "completed", "stopped", "error"):
         return status
-    
+
     # Check for errors
     if state.get("last_error") or state.get("health") == "degraded":
         return "error"
-    
+
     # Check if there's an active run_id but no recent activity
     run_id = state.get("run_id")
     if run_id:
         # Has run_id - check for activity
         counters = state.get("counters", {})
         usage = state.get("usage", {})
-        
+
         # If there's any activity, consider it running
         if counters.get("teacher_generated", 0) > 0:
             return "running"
@@ -732,10 +740,10 @@ def resolve_status(state: Dict[str, Any]) -> str:
             return "running"
         if counters.get("train_step", 0) > 0:
             return "running"
-        
+
         # No activity - idle
         return "idle"
-    
+
     # Default to idle if no run_id
     return "idle"
 
@@ -1141,8 +1149,17 @@ def _rotate_events_log(events_file: Path) -> None:
     HOW IT WORKS:
         - Renames current log to .1, .2, etc.
         - Deletes oldest if over retention limit
+
+    SECURITY:
+        - Ensures the rotation target is a subdirectory of the runs folder
     """
     run_dir = events_file.parent
+
+    # SECURITY: Ensure the rotation target is a subdirectory of the resolved runs path.
+    # This prevents path traversal even if get_run_dir was bypassed.
+    runs_root = (Path(AUTOTRAIN_DIR) / "runs").resolve()
+    if runs_root not in run_dir.resolve().parents and run_dir.resolve() != runs_root:
+        return
 
     # Remove oldest if at limit
     oldest = run_dir / f"events.jsonl.{EVENT_LOG_RETENTION}"
@@ -1517,7 +1534,7 @@ def main():
         python -m heidi_engine.telemetry emit <type> <message>
     """
     import argparse
-    
+
     parser = argparse.ArgumentParser(prog="heidi-engine telemetry")
     subparsers = parser.add_subparsers(dest="command")
 


### PR DESCRIPTION
I have identified and fixed a CRITICAL path traversal vulnerability in the `heidi_engine/telemetry.py` module.

### Vulnerability
The `get_run_dir` function was using the `run_id` (which can be provided via CLI or environment variables) directly to construct filesystem paths. This allowed a malicious user to provide a `run_id` like `../../etc` or `/tmp/hijack`, causing the engine to create directories or operate on files outside the designated `runs` folder.

### Fix
1.  **Sanitization**: Updated `get_run_dir` to use `Path(run_id).name`. This extracts only the final component of the path, stripping any relative or absolute directory markers.
2.  **Safe Fallback**: Added a check to fallback to `default_run` if the sanitized name is empty or represents reserved path components (`.` or `..`).
3.  **Defense in Depth**: Hardened `_rotate_events_log` by adding a check to ensure that any file operations are strictly confined to the `AUTOTRAIN_DIR/runs` hierarchy.

### Verification
- Created and ran a test script `check_vuln.py` to confirm that `run_id="../../traversal_test"` no longer creates a directory in the parent of the `runs` folder.
- Created and ran `check_abs_vuln.py` to confirm that absolute paths (e.g., `/tmp/abs_test`) are also correctly confined.
- Verified that `.` and `..` fall back to `default_run`.
- Ran the full `pytest` suite (19 tests passed).
- Performed linting with `ruff` and fixed several whitespace/import issues.

All security learnings have been documented in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [16010029054717005691](https://jules.google.com/task/16010029054717005691) started by @heidi-dang*