### PR TITLE
🛡️ Sentinel: [High] Fix missing authentication on telemetry endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Security Journal
+
+## 2025-01-24 - Missing Authentication on Telemetry Endpoints
+**Vulnerability:** Telemetry HTTP endpoints (`/status`, `/`) were completely unprotected, allowing any local user to view training state, usage, and costs.
+**Learning:** Initial implementation prioritized ease of use and local-only binding (`127.0.0.1`) but neglected defense-in-depth requirements for multi-user or shared environments.
+**Prevention:** Always implement at least Basic Authentication for any endpoint exposing state or metadata, even if restricted to loopback. Use random session-specific credentials if no configuration is provided.

--- a/heidi_engine/telemetry.py
+++ b/heidi_engine/telemetry.py
@@ -56,9 +56,11 @@ CONFIG VALIDATION:
 """
 
 import atexit
+import base64
 import json
 import os
 import re
+import secrets
 import stat
 import sys
 import threading
@@ -1380,10 +1382,56 @@ def start_http_server(port: int = 7779) -> None:
                 redacted[key] = value
         return redacted
 
+    # SECURITY: Session-specific random password if TELEMETRY_PASS is not set.
+    # Prevents hardcoded 'admin' default and ensures defense-in-depth.
+    _session_pass = os.environ.get("TELEMETRY_PASS")
+    if not _session_pass:
+        _session_pass = secrets.token_urlsafe(16)
+        print(f"[SECURITY] TELEMETRY_PASS not set. Generated random password: {_session_pass}", file=sys.stderr)
+
     class StateHandler(BaseHTTPRequestHandler):
         """HTTP handler with security restrictions."""
 
+        def check_auth(self) -> bool:
+            """Check Basic Authentication."""
+            # Exempt /health from authentication for infrastructure compatibility
+            if self.path == "/health":
+                return True
+
+            auth_header = self.headers.get("Authorization")
+            if not auth_header or not auth_header.startswith("Basic "):
+                self.send_auth_request()
+                return False
+
+            try:
+                auth_decoded = base64.b64decode(auth_header[6:]).decode()
+                if ":" not in auth_decoded:
+                    self.send_auth_request()
+                    return False
+                user, password = auth_decoded.split(":", 1)
+
+                if secrets.compare_digest(user, "admin") and secrets.compare_digest(
+                    password, _session_pass
+                ):
+                    return True
+            except Exception:
+                pass
+
+            self.send_auth_request()
+            return False
+
+        def send_auth_request(self):
+            """Send 401 Unauthorized response."""
+            self.send_response(401)
+            self.send_header("WWW-Authenticate", 'Basic realm="Heidi Engine Telemetry"')
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"Authentication required")
+
         def do_GET(self):
+            if not self.check_auth():
+                return
+
             if self.path == "/health":
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing authentication on telemetry HTTP endpoints.
🎯 Impact: Any local user on the system could view training state, usage, and costs by querying the loopback telemetry server.
🔧 Fix: Implemented HTTP Basic Authentication for `/status` and `/` endpoints.
- Username is 'admin'.
- Password is taken from `TELEMETRY_PASS` env var.
- If `TELEMETRY_PASS` is unset, a secure random password is generated per session and logged to `stderr`.
- `/health` remains unauthenticated for infrastructure compatibility.
✅ Verification: Confirmed via manual curl tests that endpoints are protected and accept correct credentials.

---
*PR created automatically by Jules for task [13389982335532377533](https://jules.google.com/task/13389982335532377533) started by @heidi-dang*