### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in telemetry and telemetry bug

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** Telemetry HTTP endpoints (`/status`, `/`) were completely unprotected, allowing any local user to view training state, usage, and costs.
 **Learning:** Initial implementation prioritized ease of use and local-only binding (`127.0.0.1`) but neglected defense-in-depth requirements for multi-user or shared environments.
 **Prevention:** Always implement at least Basic Authentication for any endpoint exposing state or metadata, even if restricted to loopback. Use random session-specific credentials if no configuration is provided.
+
+## 2025-05-15 - Path Traversal in Telemetry Run Directory Resolution
+**Vulnerability:** The `get_run_dir` function in `heidi_engine/telemetry.py` used direct string concatenation of `run_id`, allowing an attacker to use `..` sequences to access files outside the `runs/` directory (e.g., `/etc/passwd`).
+**Learning:** Even internal helper functions used for path construction must sanitize inputs if those inputs can be influenced by environment variables or external calls. Relying on `Path() / run_id` is unsafe if `run_id` contains traversal sequences.
+**Prevention:** Always sanitize filename/directory components using `Path(component).name` or equivalent to ensure they remain within the intended parent directory.

--- a/heidi_engine/telemetry.py
+++ b/heidi_engine/telemetry.py
@@ -410,7 +410,9 @@ def get_run_dir(run_id: Optional[str] = None) -> Path:
     """
     if run_id is None:
         run_id = get_run_id()
-    return Path(AUTOTRAIN_DIR) / "runs" / run_id
+    # SECURITY: Use Path(run_id).name to prevent path traversal.
+    # This ensures run_id cannot contain ".." or absolute paths that escape the runs directory.
+    return Path(AUTOTRAIN_DIR) / "runs" / Path(run_id).name
 
 
 def get_events_path(run_id: Optional[str] = None) -> Path:
@@ -731,11 +733,6 @@ def get_state(run_id: Optional[str] = None) -> Dict[str, Any]:
             "counters": get_default_counters(),
             "usage": get_default_usage(),
         }
-
-    # BOLT OPTIMIZATION: Check thread-safe state cache
-    cached = _state_cache.get(target_run_id, state_file)
-    if cached:
-        return cached
 
     try:
         with open(state_file) as f:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,33 @@
+
+import os
+import pytest
+from pathlib import Path
+from heidi_engine.telemetry import get_run_dir, AUTOTRAIN_DIR
+
+def test_get_run_dir_path_traversal_protection():
+    """
+    Test that get_run_dir sanitizes run_id to prevent path traversal.
+    """
+    malicious_run_id = "../../../../../../../../../etc/passwd"
+    run_dir = get_run_dir(malicious_run_id)
+
+    # It should only take the 'name' part (passwd)
+    assert run_dir.name == "passwd"
+
+    # It should be located inside AUTOTRAIN_DIR/runs
+    expected_base = Path(AUTOTRAIN_DIR).resolve() / "runs"
+    assert str(run_dir.resolve()).startswith(str(expected_base))
+
+def test_get_run_dir_absolute_path_protection():
+    """
+    Test that get_run_dir sanitizes absolute run_id to prevent escaping.
+    """
+    malicious_run_id = "/tmp/evil_run"
+    run_dir = get_run_dir(malicious_run_id)
+
+    # It should only take the 'name' part (evil_run)
+    assert run_dir.name == "evil_run"
+
+    # It should be located inside AUTOTRAIN_DIR/runs
+    expected_base = Path(AUTOTRAIN_DIR).resolve() / "runs"
+    assert str(run_dir.resolve()).startswith(str(expected_base))


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Path traversal in `get_run_dir` allowed accessing files outside the intended runs directory via malicious `RUN_ID`. Also, a `NameError` in `get_state` caused telemetry failures.
🎯 Impact: Attackers could potentially overwrite or read sensitive files if they could control the `RUN_ID` environment variable or CLI argument. The `NameError` led to runtime crashes.
🔧 Fix: Sanitized `run_id` to its basename and removed the broken cache check.
✅ Verification: Added `tests/test_security.py` and ran existing telemetry tests. All 23 tests passed.

---
*PR created automatically by Jules for task [8126109880987622768](https://jules.google.com/task/8126109880987622768) started by @heidi-dang*