### PR TITLE
Fix path traversal and unit test gate stability

### DIFF
--- a/heidi_engine/dashboard.py
+++ b/heidi_engine/dashboard.py
@@ -133,8 +133,14 @@ data_cache: deque = deque(maxlen=data_tail_lines)
 
 
 def get_run_dir(run_id: str) -> Path:
-    """Get the run directory path."""
-    return Path(AUTOTRAIN_DIR) / "runs" / run_id
+    """
+    Get the run directory path.
+
+    SECURITY:
+        Sanitizes run_id to prevent path traversal.
+    """
+    safe_run_id = Path(run_id).name
+    return Path(AUTOTRAIN_DIR) / "runs" / safe_run_id
 
 
 def get_events_path(run_id: str) -> Path:

--- a/heidi_engine/telemetry.py
+++ b/heidi_engine/telemetry.py
@@ -68,7 +68,7 @@ import threading
 import time
 import uuid
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -405,12 +405,17 @@ def get_run_dir(run_id: Optional[str] = None) -> Path:
         Creates runs/<run_id>/ directory structure.
         All run-specific files go here.
 
+    SECURITY:
+        Sanitizes run_id to prevent path traversal.
+
     TUNABLE:
         - Modify directory structure by changing path construction
     """
     if run_id is None:
         run_id = get_run_id()
-    return Path(AUTOTRAIN_DIR) / "runs" / run_id
+    # SECURITY: Sanitize run_id to prevent path traversal
+    safe_run_id = Path(run_id).name
+    return Path(AUTOTRAIN_DIR) / "runs" / safe_run_id
 
 
 def get_events_path(run_id: Optional[str] = None) -> Path:
@@ -436,6 +441,9 @@ def get_run_id() -> str:
         - Uses RUN_ID env var if set
         - Otherwise generates a new UUID
         - Stores in global for subsequent calls
+
+    SECURITY:
+        Sanitizes RUN_ID from environment to prevent path traversal.
     """
     global RUN_ID
     if not RUN_ID:
@@ -443,6 +451,9 @@ def get_run_id() -> str:
     if not RUN_ID:
         RUN_ID = str(uuid.uuid4())[:8]
         RUN_ID = f"run_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{RUN_ID}"
+
+    # SECURITY: Sanitize RUN_ID to prevent path traversal
+    RUN_ID = Path(RUN_ID).name
     return RUN_ID
 
 
@@ -666,8 +677,8 @@ def init_telemetry(
             "counters": get_default_counters(),
             "usage": get_default_usage(),
             "config": {},  # Don't store config in state for security
-            "started_at": datetime.utcnow().isoformat(),
-            "updated_at": datetime.utcnow().isoformat(),
+            "started_at": datetime.now(timezone.utc).isoformat(),
+            "updated_at": datetime.now(timezone.utc).isoformat(),
         }
 
         # Save initial state atomically
@@ -732,10 +743,8 @@ def get_state(run_id: Optional[str] = None) -> Dict[str, Any]:
             "usage": get_default_usage(),
         }
 
-    # BOLT OPTIMIZATION: Check thread-safe state cache
-    cached = _state_cache.get(target_run_id, state_file)
-    if cached:
-        return cached
+    # BOLT OPTIMIZATION: A second redundant cache check was removed here
+    # as it used an undefined variable `target_run_id`.
 
     try:
         with open(state_file) as f:
@@ -830,7 +839,7 @@ def save_state(state: Dict[str, Any], run_id: Optional[str] = None) -> None:
     temp_file = state_file.with_suffix(".tmp")
 
     # Update timestamp
-    state["updated_at"] = datetime.utcnow().isoformat()
+    state["updated_at"] = datetime.now(timezone.utc).isoformat()
 
     # Write to temp file
     with open(temp_file, "w") as f:
@@ -1110,7 +1119,7 @@ def emit_event(
     # Build event with schema version
     event = {
         "event_version": EVENT_VERSION,
-        "ts": datetime.utcnow().isoformat(),
+        "ts": datetime.now(timezone.utc).isoformat(),
         "run_id": run_id,
         "round": round_num if round_num is not None else state.get("current_round", 0),
         "stage": stage or state.get("current_stage", "unknown"),

--- a/scripts/03_unit_test_gate.py
+++ b/scripts/03_unit_test_gate.py
@@ -40,6 +40,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import textwrap
 from typing import Any, Dict, List, Tuple
 
 # =============================================================================
@@ -213,6 +214,9 @@ def test_python_code(code: str, temp_dir: str, execution_timeout: int = 5) -> Tu
     # Write code to temp file
     test_file = os.path.join(temp_dir, "test_code.py")
 
+    # SECURITY/STABILITY: Indent the user code so it is properly nested in the try block
+    indented_code = textwrap.indent(code, "    ")
+
     # Wrap code to capture output safely
     wrapped_code = f"""
 import sys
@@ -229,7 +233,7 @@ try:
     sys.stderr = stderr_capture
 
     # Execute the user's code
-{code}
+{indented_code}
 
     sys.stdout = original_stdout
     sys.stderr = original_stderr


### PR DESCRIPTION
Implemented path traversal protection in `heidi_engine/telemetry.py` and `heidi_engine/dashboard.py` by using `Path(run_id).name` to sanitize user-provided run identifiers. This prevents malicious actors from reading or writing files outside the intended `runs/` directory.

Additionally, fixed a critical bug in `scripts/03_unit_test_gate.py` where multi-line Python code samples would fail to execute due to incorrect indentation within the execution wrapper. The wrapper now uses `textwrap.indent` to ensure proper nesting.

Finally, modernized `heidi_engine/telemetry.py` by replacing deprecated `datetime.utcnow()` calls with `datetime.now(timezone.utc)` and removed a broken redundant cache check that incorrectly referenced an undefined variable.

All changes were verified with targeted scripts and existing project tests (21 passed). Temporary artifacts were removed before submission.

---
*PR created automatically by Jules for task [3327075848239083014](https://jules.google.com/task/3327075848239083014) started by @heidi-dang*