### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in telemetry run_id

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** Telemetry HTTP endpoints (`/status`, `/`) were completely unprotected, allowing any local user to view training state, usage, and costs.
 **Learning:** Initial implementation prioritized ease of use and local-only binding (`127.0.0.1`) but neglected defense-in-depth requirements for multi-user or shared environments.
 **Prevention:** Always implement at least Basic Authentication for any endpoint exposing state or metadata, even if restricted to loopback. Use random session-specific credentials if no configuration is provided.
+
+## 2025-01-24 - Path Traversal in Telemetry Run ID
+**Vulnerability:** The `run_id` was used directly in path construction (e.g., `runs/<run_id>/state.json`), allowing an attacker to read/write files outside the intended directory via `../` sequences or absolute paths.
+**Learning:** Even internally-generated or environment-sourced IDs must be sanitized if they are used as path components. `os.path.basename` is an effective first line of defense.
+**Prevention:** Always sanitize input used in file paths using `os.path.basename` and ensure the resulting path is contained within the intended base directory. Provide safe fallbacks for empty or dangerous strings like `.` or `..`.

--- a/heidi_engine/telemetry.py
+++ b/heidi_engine/telemetry.py
@@ -405,12 +405,23 @@ def get_run_dir(run_id: Optional[str] = None) -> Path:
         Creates runs/<run_id>/ directory structure.
         All run-specific files go here.
 
+    SECURITY:
+        - Sanitizes run_id to prevent path traversal.
+        - Ensures run_dir is always within AUTOTRAIN_DIR/runs.
+
     TUNABLE:
         - Modify directory structure by changing path construction
     """
     if run_id is None:
         run_id = get_run_id()
-    return Path(AUTOTRAIN_DIR) / "runs" / run_id
+
+    # SECURITY: Sanitize run_id to prevent path traversal
+    safe_id = os.path.basename(run_id)
+    if not safe_id or safe_id in (".", ".."):
+        # Fallback to a safe unique ID if basename is empty or dangerous
+        safe_id = f"safe_{uuid.uuid4().hex[:8]}"
+
+    return Path(AUTOTRAIN_DIR) / "runs" / safe_id
 
 
 def get_events_path(run_id: Optional[str] = None) -> Path:
@@ -436,10 +447,19 @@ def get_run_id() -> str:
         - Uses RUN_ID env var if set
         - Otherwise generates a new UUID
         - Stores in global for subsequent calls
+
+    SECURITY:
+        - Sanitizes RUN_ID from environment to prevent path traversal.
     """
     global RUN_ID
     if not RUN_ID:
-        RUN_ID = os.environ.get("RUN_ID", "")
+        raw_id = os.environ.get("RUN_ID", "")
+        if raw_id:
+            # SECURITY: Sanitize input from environment
+            RUN_ID = os.path.basename(raw_id)
+            if not RUN_ID or RUN_ID in (".", ".."):
+                RUN_ID = ""
+
     if not RUN_ID:
         RUN_ID = str(uuid.uuid4())[:8]
         RUN_ID = f"run_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{RUN_ID}"
@@ -639,7 +659,10 @@ def init_telemetry(
 
     with _lock:
         if run_id:
-            RUN_ID = run_id
+            # SECURITY: Sanitize provided run_id
+            RUN_ID = os.path.basename(run_id)
+            if not RUN_ID or RUN_ID in (".", ".."):
+                RUN_ID = ""
 
         run_id = get_run_id()
         run_dir = get_run_dir(run_id)
@@ -731,11 +754,6 @@ def get_state(run_id: Optional[str] = None) -> Dict[str, Any]:
             "counters": get_default_counters(),
             "usage": get_default_usage(),
         }
-
-    # BOLT OPTIMIZATION: Check thread-safe state cache
-    cached = _state_cache.get(target_run_id, state_file)
-    if cached:
-        return cached
 
     try:
         with open(state_file) as f:

--- a/tests/test_path_traversal.py
+++ b/tests/test_path_traversal.py
@@ -1,0 +1,71 @@
+
+import os
+import tempfile
+import uuid
+from pathlib import Path
+from heidi_engine import telemetry
+
+def test_get_run_dir_path_traversal():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        telemetry.AUTOTRAIN_DIR = tmp_dir
+        expected_base = Path(tmp_dir) / "runs"
+
+        # Relative traversal
+        malicious_id = "../../evil"
+        run_dir = telemetry.get_run_dir(malicious_id)
+        assert run_dir.name == "evil"
+        assert run_dir.parent == expected_base
+
+        # Absolute traversal
+        absolute_id = "/tmp/evil_abs"
+        run_dir_abs = telemetry.get_run_dir(absolute_id)
+        assert run_dir_abs.name == "evil_abs"
+        assert run_dir_abs.parent == expected_base
+
+        # Dangerous names (., ..)
+        for dangerous in (".", "..", ""):
+            run_dir_dangerous = telemetry.get_run_dir(dangerous)
+            assert run_dir_dangerous.name.startswith("safe_")
+            assert run_dir_dangerous.parent == expected_base
+
+def test_init_telemetry_sanitization():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        telemetry.AUTOTRAIN_DIR = tmp_dir
+
+        # Should sanitize run_id passed to init_telemetry
+        malicious_id = "../sanitized_run"
+        run_id = telemetry.init_telemetry(run_id=malicious_id)
+
+        assert run_id == "sanitized_run"
+        assert (Path(tmp_dir) / "runs" / "sanitized_run").exists()
+
+def test_get_run_id_env_sanitization():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        telemetry.AUTOTRAIN_DIR = tmp_dir
+
+        # Mock environment variable
+        os.environ["RUN_ID"] = "../../env_malicious"
+        telemetry.RUN_ID = "" # Reset global
+
+        run_id = telemetry.get_run_id()
+        assert run_id == "env_malicious"
+
+        # Clean up
+        del os.environ["RUN_ID"]
+        telemetry.RUN_ID = ""
+
+def test_get_run_id_dangerous_env_fallback():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        telemetry.AUTOTRAIN_DIR = tmp_dir
+
+        # Mock dangerous environment variable
+        os.environ["RUN_ID"] = ".."
+        telemetry.RUN_ID = "" # Reset global
+
+        run_id = telemetry.get_run_id()
+        assert run_id.startswith("run_")
+        assert run_id != ".."
+
+        # Clean up
+        del os.environ["RUN_ID"]
+        telemetry.RUN_ID = ""


### PR DESCRIPTION
I have identified and fixed a high-priority path traversal vulnerability in the `heidi_engine/telemetry.py` module. The vulnerability allowed a malicious or malformed `run_id` (sourced from environment variables or direct function calls) to read or write files outside the intended `runs/` directory.

### Fix Details:
1.  **Path Sanitization:** Updated `get_run_dir`, `get_run_id`, and `init_telemetry` to use `os.path.basename()` for all `run_id` inputs.
2.  **Fallback Logic:** Added safe unique ID generation for cases where sanitization results in empty or dangerous names (e.g., `.`, `..`).
3.  **NameError Fix:** Resolved a `NameError` in the `get_state` function where an undefined variable `target_run_id` was being used in a redundant cache check.
4.  **Verification:** Created a new test suite `tests/test_path_traversal.py` covering various traversal scenarios and validated the fix using a reproduction script (which has been removed after verification).
5.  **Documentation:** Updated the Sentinel security journal with learnings from this fix.

All 25 tests in the codebase now pass.

---
*PR created automatically by Jules for task [3266388388107742894](https://jules.google.com/task/3266388388107742894) started by @heidi-dang*