### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in telemetry run IDs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** Telemetry HTTP endpoints (`/status`, `/`) were completely unprotected, allowing any local user to view training state, usage, and costs.
 **Learning:** Initial implementation prioritized ease of use and local-only binding (`127.0.0.1`) but neglected defense-in-depth requirements for multi-user or shared environments.
 **Prevention:** Always implement at least Basic Authentication for any endpoint exposing state or metadata, even if restricted to loopback. Use random session-specific credentials if no configuration is provided.
+
+## 2025-05-15 - Path Traversal in Telemetry Run IDs
+**Vulnerability:** Run IDs from environment variables and function arguments were used directly to construct file paths, allowing an attacker to write or read files outside the intended `runs/` directory (e.g., `RUN_ID=../../etc`).
+**Learning:** Even internal-looking identifiers like `run_id` must be treated as untrusted input if they can be influenced by environment variables or API calls.
+**Prevention:** Always use `os.path.basename()` to sanitize file-system identifiers. Implement a safe fallback (like a UUID) for malicious inputs like `..` or empty strings.

--- a/heidi_engine/telemetry.py
+++ b/heidi_engine/telemetry.py
@@ -405,12 +405,22 @@ def get_run_dir(run_id: Optional[str] = None) -> Path:
         Creates runs/<run_id>/ directory structure.
         All run-specific files go here.
 
+    SECURITY:
+        - Sanitizes run_id to prevent path traversal.
+
     TUNABLE:
         - Modify directory structure by changing path construction
     """
     if run_id is None:
         run_id = get_run_id()
-    return Path(AUTOTRAIN_DIR) / "runs" / run_id
+
+    # SECURITY: Sanitize run_id to prevent path traversal
+    safe_run_id = os.path.basename(run_id)
+    if not safe_run_id or safe_run_id in (".", ".."):
+        # Fallback to safe unique ID if malicious or empty
+        safe_run_id = f"safe_{uuid.uuid4().hex[:8]}"
+
+    return Path(AUTOTRAIN_DIR) / "runs" / safe_run_id
 
 
 def get_events_path(run_id: Optional[str] = None) -> Path:
@@ -436,10 +446,19 @@ def get_run_id() -> str:
         - Uses RUN_ID env var if set
         - Otherwise generates a new UUID
         - Stores in global for subsequent calls
+
+    SECURITY:
+        - Sanitizes input from environment variables
     """
     global RUN_ID
     if not RUN_ID:
-        RUN_ID = os.environ.get("RUN_ID", "")
+        raw_id = os.environ.get("RUN_ID", "")
+        if raw_id:
+            # SECURITY: Sanitize ID from environment
+            RUN_ID = os.path.basename(raw_id)
+            if not RUN_ID or RUN_ID in (".", ".."):
+                RUN_ID = ""  # Force regeneration if unsafe
+
     if not RUN_ID:
         RUN_ID = str(uuid.uuid4())[:8]
         RUN_ID = f"run_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{RUN_ID}"
@@ -639,7 +658,10 @@ def init_telemetry(
 
     with _lock:
         if run_id:
-            RUN_ID = run_id
+            # SECURITY: Sanitize direct input
+            RUN_ID = os.path.basename(run_id)
+            if not RUN_ID or RUN_ID in (".", ".."):
+                RUN_ID = ""  # Fall back to get_run_id logic
 
         run_id = get_run_id()
         run_dir = get_run_dir(run_id)

--- a/tests/test_path_traversal_fix.py
+++ b/tests/test_path_traversal_fix.py
@@ -1,0 +1,66 @@
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from heidi_engine import telemetry
+
+class TestPathTraversal(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.old_autotrain_dir = telemetry.AUTOTRAIN_DIR
+        telemetry.AUTOTRAIN_DIR = self.test_dir
+        # Reset global state
+        telemetry.RUN_ID = ""
+
+    def tearDown(self):
+        telemetry.AUTOTRAIN_DIR = self.old_autotrain_dir
+        shutil.rmtree(self.test_dir)
+
+    def test_get_run_dir_sanitization(self):
+        """Test that get_run_dir sanitizes malicious run_ids."""
+        malicious_id = "../../etc"
+        run_dir = telemetry.get_run_dir(malicious_id)
+
+        # Ensure the run_dir is still within the test_dir/runs/
+        expected_base = Path(self.test_dir) / "runs"
+        self.assertTrue(str(run_dir).startswith(str(expected_base)), f"Path escaped base: {run_dir}")
+        self.assertEqual(run_dir.name, "etc")
+
+    def test_get_run_dir_fallback(self):
+        """Test that get_run_dir falls back to a safe ID for dangerous inputs."""
+        for dangerous_id in (".", "..", "/"):
+            run_dir = telemetry.get_run_dir(dangerous_id)
+            self.assertTrue(run_dir.name.startswith("safe_"), f"Failed for {dangerous_id}: {run_dir.name}")
+
+    def test_get_run_id_env_sanitization(self):
+        """Test that get_run_id sanitizes RUN_ID from environment."""
+        os.environ["RUN_ID"] = "../hidden_run"
+        try:
+            run_id = telemetry.get_run_id()
+            self.assertEqual(run_id, "hidden_run")
+        finally:
+            del os.environ["RUN_ID"]
+
+    def test_get_run_id_env_unsafe_fallback(self):
+        """Test that get_run_id regenerates if environment RUN_ID is unsafe."""
+        os.environ["RUN_ID"] = ".."
+        try:
+            run_id = telemetry.get_run_id()
+            self.assertFalse(run_id == "..")
+            self.assertTrue(run_id.startswith("run_"))
+        finally:
+            del os.environ["RUN_ID"]
+
+    def test_init_telemetry_sanitization(self):
+        """Test that init_telemetry sanitizes direct run_id input."""
+        malicious_id = "../evil"
+        run_id = telemetry.init_telemetry(run_id=malicious_id)
+        self.assertEqual(run_id, "evil")
+
+        # Verify directory exists with sanitized name
+        run_dir = Path(self.test_dir) / "runs" / "evil"
+        self.assertTrue(run_dir.exists())
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Path traversal in telemetry run IDs.
🎯 Impact: Attackers could potentially read or write files outside the intended `runs/` directory by manipulating the `RUN_ID` environment variable or function arguments (e.g., `RUN_ID=../../etc`).
🔧 Fix: Sanitized `run_id` using `os.path.basename()` in `get_run_id`, `get_run_dir`, and `init_telemetry`. Added fallback to a safe UUID-based ID for malicious or empty inputs.
✅ Verification: Created `tests/test_path_traversal_fix.py` which verifies that malicious inputs are sanitized and do not escape the base directory. Existing unit tests for redaction pass.

---
*PR created automatically by Jules for task [10385526285725625119](https://jules.google.com/task/10385526285725625119) started by @heidi-dang*