### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix path traversal in telemetry

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** Telemetry HTTP endpoints (`/status`, `/`) were completely unprotected, allowing any local user to view training state, usage, and costs.
 **Learning:** Initial implementation prioritized ease of use and local-only binding (`127.0.0.1`) but neglected defense-in-depth requirements for multi-user or shared environments.
 **Prevention:** Always implement at least Basic Authentication for any endpoint exposing state or metadata, even if restricted to loopback. Use random session-specific credentials if no configuration is provided.
+
+## 2025-01-24 - Path Traversal in Telemetry Run Directory
+**Vulnerability:** The `get_run_dir` function in `heidi_engine/telemetry.py` used the `run_id` directly to construct file paths, allowing absolute path traversal (e.g., `/tmp/evil`) and relative path traversal (e.g., `../../evil`) outside the intended `runs/` directory.
+**Learning:** Even internal-only identifiers should be sanitized before being used in path construction, especially when they might be influenced by environment variables or CLI arguments.
+**Prevention:** Use `Path(id).name` to strip directory components from identifiers before using them to construct file paths. Implement fallback logic for empty or reserved names like `.` and `..`.

--- a/heidi_engine/telemetry.py
+++ b/heidi_engine/telemetry.py
@@ -405,12 +405,26 @@ def get_run_dir(run_id: Optional[str] = None) -> Path:
         Creates runs/<run_id>/ directory structure.
         All run-specific files go here.
 
+    SECURITY:
+        - Sanitizes run_id to prevent path traversal
+        - Uses Path(run_id).name to strip directory segments
+        - Fallback to safe unique ID if input is dangerous
+
     TUNABLE:
         - Modify directory structure by changing path construction
     """
     if run_id is None:
         run_id = get_run_id()
-    return Path(AUTOTRAIN_DIR) / "runs" / run_id
+
+    # SECURITY: Sanitize run_id to prevent path traversal (e.g. "../../etc/passwd")
+    # Path(run_id).name strips all directory components and only returns the final filename.
+    safe_run_id = Path(run_id).name
+
+    # Fallback if sanitized ID is empty or refers to current/parent directory
+    if not safe_run_id or safe_run_id in (".", ".."):
+        safe_run_id = f"safe_{uuid.uuid4().hex[:8]}"
+
+    return Path(AUTOTRAIN_DIR) / "runs" / safe_run_id
 
 
 def get_events_path(run_id: Optional[str] = None) -> Path:
@@ -731,11 +745,6 @@ def get_state(run_id: Optional[str] = None) -> Dict[str, Any]:
             "counters": get_default_counters(),
             "usage": get_default_usage(),
         }
-
-    # BOLT OPTIMIZATION: Check thread-safe state cache
-    cached = _state_cache.get(target_run_id, state_file)
-    if cached:
-        return cached
 
     try:
         with open(state_file) as f:


### PR DESCRIPTION
This PR addresses a critical path traversal vulnerability in the telemetry module and resolves a `NameError` that was impacting system stability.

### 🚨 Severity: CRITICAL/HIGH
### 💡 Vulnerability: Path Traversal
The `get_run_dir` function was using the `run_id` directly in path construction. Since `run_id` can be influenced by environment variables or CLI arguments, an attacker or misconfigured environment could specify absolute paths (e.g., `/tmp/evil`) or relative paths (e.g., `../../evil`) to write or read telemetry data outside the intended `runs/` directory.

### 🎯 Impact:
Exploitation could allow an attacker to overwrite sensitive system files or read arbitrary files if they can control the `run_id` input, leading to potential data loss, information disclosure, or system compromise.

### 🔧 Fix:
- Implemented sanitization in `get_run_dir` using `Path(run_id).name` to strip all directory components.
- Added a fallback to a safe, unique ID if the resulting `run_id` is empty or refers to `.` or `..`.
- Resolved a `NameError` in `get_state` that was discovered during regression testing, where a redundant cache check used an undefined variable `target_run_id`.

### ✅ Verification:
- Created a verification script `verify_traversal.py` which confirmed that absolute and relative paths are now correctly jailed within the `runs/` directory.
- Ran the full test suite (`pytest tests/`) and verified that all 21 tests pass, including the state cache tests.
- Updated `.jules/sentinel.md` with details of the vulnerability and prevention steps.

---
*PR created automatically by Jules for task [7088198973642608729](https://jules.google.com/task/7088198973642608729) started by @heidi-dang*