### PR TITLE
⚡ Bolt: Fix broken cache check in get_state

### DIFF
--- a/heidi_engine/telemetry.py
+++ b/heidi_engine/telemetry.py
@@ -732,11 +732,6 @@ def get_state(run_id: Optional[str] = None) -> Dict[str, Any]:
             "usage": get_default_usage(),
         }
 
-    # BOLT OPTIMIZATION: Check thread-safe state cache
-    cached = _state_cache.get(target_run_id, state_file)
-    if cached:
-        return cached
-
     try:
         with open(state_file) as f:
             state = json.load(f)


### PR DESCRIPTION
💡 What: Removed a redundant and broken cache check in the `get_state` function of `heidi_engine/telemetry.py`.

🎯 Why: The code referenced an undefined variable `target_run_id`, causing a `NameError` and preventing tests from passing. This also removes dead code from a high-frequency polling path (e.g., dashboard refreshes).

📊 Impact: Resolves a critical bug that crashed telemetry state retrieval and provides a micro-optimization by removing an unnecessary second cache check (the state is already checked at the start of the function using `resolved_run_id`).

🔬 Measurement: Verified with `pytest tests/test_telemetry_cache.py` and the full test suite `pytest tests/`.

---
*PR created automatically by Jules for task [1994160770846366147](https://jules.google.com/task/1994160770846366147) started by @heidi-dang*