### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Harden unit test execution sandbox

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,7 @@
 **Vulnerability:** Telemetry HTTP endpoints (`/status`, `/`) were completely unprotected, allowing any local user to view training state, usage, and costs.
 **Learning:** Initial implementation prioritized ease of use and local-only binding (`127.0.0.1`) but neglected defense-in-depth requirements for multi-user or shared environments.
 **Prevention:** Always implement at least Basic Authentication for any endpoint exposing state or metadata, even if restricted to loopback. Use random session-specific credentials if no configuration is provided.
+## 2025-04-20 - Unsafe Code Execution Environment in Unit Test Gate
+**Vulnerability:** The unit test gate executed generated code in an environment inheriting all parent environment variables, potentially leaking sensitive API keys (e.g., OPENAI_API_KEY) to untrusted code. Additionally, the sandbox could be easily escaped using standard Python introspection and library imports.
+**Learning:** Executing code in a subprocess requires strict control over the environment and imports. Blocklists for dangerous patterns are easily bypassed; a combination of allowlisting environment variables and robust pattern matching for sandbox escape sequences (like `__subclasses__`) is required.
+**Prevention:** Use environment variable allowlists when spawning subprocesses for code execution. Extend dangerous pattern detection to include introspection attributes and common sandbox escape libraries like `importlib` and `inspect`.

--- a/heidi_engine/telemetry.py
+++ b/heidi_engine/telemetry.py
@@ -733,7 +733,7 @@ def get_state(run_id: Optional[str] = None) -> Dict[str, Any]:
         }
 
     # BOLT OPTIMIZATION: Check thread-safe state cache
-    cached = _state_cache.get(target_run_id, state_file)
+    cached = _state_cache.get(resolved_run_id)
     if cached:
         return cached
 

--- a/scripts/03_unit_test_gate.py
+++ b/scripts/03_unit_test_gate.py
@@ -40,6 +40,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import textwrap
 from typing import Any, Dict, List, Tuple
 
 # =============================================================================
@@ -67,8 +68,8 @@ CODE_BLOCK_PATTERNS = [
 # TUNABLE: Add more dangerous patterns to block
 DANGEROUS_PATTERNS = [
     # Dangerous imports (including comma-separated and aliased)
-    r"\bimport\s+[^#\n]*\b(os|subprocess|sys|shutil|socket|requests|urllib|pathlib|pickle|pty|code|bdb|pdb|multiprocessing|threading|tempfile|ftplib|smtplib|telnetlib|http|xmlrpc)\b",
-    r"\bfrom\s+(os|subprocess|sys|shutil|socket|requests|urllib|pathlib|pickle|pty|code|bdb|pdb|multiprocessing|threading|tempfile|ftplib|smtplib|telnetlib|http|xmlrpc)\b",
+    r"\bimport\s+[^#\n]*\b(os|subprocess|sys|shutil|socket|requests|urllib|pathlib|pickle|pty|code|bdb|pdb|multiprocessing|threading|tempfile|ftplib|smtplib|telnetlib|http|xmlrpc|importlib|builtins|gc|inspect|types)\b",
+    r"\bfrom\s+(os|subprocess|sys|shutil|socket|requests|urllib|pathlib|pickle|pty|code|bdb|pdb|multiprocessing|threading|tempfile|ftplib|smtplib|telnetlib|http|xmlrpc|importlib|builtins|gc|inspect|types)\b",
     # Dangerous built-ins
     r"\beval\s*\(",
     r"\bexec\s*\(",
@@ -84,6 +85,12 @@ DANGEROUS_PATTERNS = [
     r"\bshelve\.open\b",
     # File operations (specifically writing/appending)
     r"\bopen\s*\([^)]*,\s*(mode\s*=\s*)?['\"][^'\"r]*[wa+x]",
+    # Sandbox escape patterns
+    r"__builtins__",
+    r"__subclasses__",
+    r"__globals__",
+    r"__base__",
+    r"__mro__",
 ]
 
 
@@ -213,6 +220,9 @@ def test_python_code(code: str, temp_dir: str, execution_timeout: int = 5) -> Tu
     # Write code to temp file
     test_file = os.path.join(temp_dir, "test_code.py")
 
+    # Indent code for wrapping
+    indented_code = textwrap.indent(code, "    ")
+
     # Wrap code to capture output safely
     wrapped_code = f"""
 import sys
@@ -229,7 +239,7 @@ try:
     sys.stderr = stderr_capture
 
     # Execute the user's code
-{code}
+{indented_code}
 
     sys.stdout = original_stdout
     sys.stderr = original_stderr
@@ -255,6 +265,14 @@ except Exception as e:
     except SyntaxError as e:
         return False, "", f"Syntax error: {e}"
 
+    # Create sanitized environment - use allowlist for security
+    # Only allow safe, standard environment variables
+    safe_vars = ["PATH", "LANG", "PYTHONIOENCODING", "USER", "HOME", "PWD", "SHELL"]
+    sanitized_env = {k: os.environ[k] for k in safe_vars if k in os.environ}
+
+    # Ensure PYTHONPATH includes temp_dir
+    sanitized_env["PYTHONPATH"] = temp_dir
+
     # Try to execute with timeout
     try:
         result = subprocess.run(
@@ -263,7 +281,7 @@ except Exception as e:
             text=True,
             timeout=execution_timeout,
             cwd=temp_dir,
-            env={**os.environ, "PYTHONPATH": temp_dir},
+            env=sanitized_env,
         )
 
         stdout = result.stdout
@@ -367,7 +385,9 @@ def load_jsonl(path: str) -> List[Dict[str, Any]]:
 
 def save_jsonl(samples: List[Dict[str, Any]], path: str) -> None:
     """Save samples to JSONL file."""
-    os.makedirs(os.path.dirname(path), exist_ok=True)
+    dirname = os.path.dirname(path)
+    if dirname:
+        os.makedirs(dirname, exist_ok=True)
 
     with open(path, "w") as f:
         for sample in samples:


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The unit test gate was executing code in an environment that inherited all sensitive environment variables and had insufficient pattern blocking for sandbox escape.
🎯 Impact: Untrusted generated code could steal API keys or escape the intended sandbox to perform unauthorized operations.
🔧 Fix:
- Implemented an environment variable allowlist for the test subprocess in `scripts/03_unit_test_gate.py`.
- Expanded `DANGEROUS_PATTERNS` to include more modules (`importlib`, `gc`, `inspect`, etc.) and introspection attributes (`__subclasses__`, `__globals__`, etc.).
- Fixed code wrapping indentation using `textwrap.indent` to ensure multi-line code executes correctly within the `try...except` block.
- Fixed a `NameError` in `heidi_engine/telemetry.py` where `target_run_id` was used instead of `resolved_run_id`.
- Improved `save_jsonl` in `scripts/03_unit_test_gate.py` to handle cases where the output path is in the current directory.
✅ Verification: Verified with a custom test script confirming environment isolation and pattern blocking. Ran existing `pytest` suite.

---
*PR created automatically by Jules for task [9471388836079481244](https://jules.google.com/task/9471388836079481244) started by @heidi-dang*