### PR TITLE
🛡️ Sentinel: [security improvement] Harden unit test gate sandbox and environment

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** Telemetry HTTP endpoints (`/status`, `/`) were completely unprotected, allowing any local user to view training state, usage, and costs.
 **Learning:** Initial implementation prioritized ease of use and local-only binding (`127.0.0.1`) but neglected defense-in-depth requirements for multi-user or shared environments.
 **Prevention:** Always implement at least Basic Authentication for any endpoint exposing state or metadata, even if restricted to loopback. Use random session-specific credentials if no configuration is provided.
+
+## 2026-02-21 - Unrestricted Subprocess Environment Leakage
+**Vulnerability:** The unit test gate executed untrusted generated code with the full parent environment (`os.environ`), leaking sensitive secrets like `OPENAI_API_KEY`.
+**Learning:** Subprocesses inherit the full environment by default in Python, which is dangerous when running code from untrusted sources (like LLM outputs).
+**Prevention:** Always filter `os.environ` to a minimal allowlist of safe variables (`PATH`, `LANG`, etc.) before passing it to `subprocess.run(env=...)`.

--- a/heidi_engine/telemetry.py
+++ b/heidi_engine/telemetry.py
@@ -732,10 +732,6 @@ def get_state(run_id: Optional[str] = None) -> Dict[str, Any]:
             "usage": get_default_usage(),
         }
 
-    # BOLT OPTIMIZATION: Check thread-safe state cache
-    cached = _state_cache.get(target_run_id, state_file)
-    if cached:
-        return cached
 
     try:
         with open(state_file) as f:

--- a/scripts/03_unit_test_gate.py
+++ b/scripts/03_unit_test_gate.py
@@ -40,6 +40,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import textwrap
 from typing import Any, Dict, List, Tuple
 
 # =============================================================================
@@ -67,8 +68,8 @@ CODE_BLOCK_PATTERNS = [
 # TUNABLE: Add more dangerous patterns to block
 DANGEROUS_PATTERNS = [
     # Dangerous imports (including comma-separated and aliased)
-    r"\bimport\s+[^#\n]*\b(os|subprocess|sys|shutil|socket|requests|urllib|pathlib|pickle|pty|code|bdb|pdb|multiprocessing|threading|tempfile|ftplib|smtplib|telnetlib|http|xmlrpc)\b",
-    r"\bfrom\s+(os|subprocess|sys|shutil|socket|requests|urllib|pathlib|pickle|pty|code|bdb|pdb|multiprocessing|threading|tempfile|ftplib|smtplib|telnetlib|http|xmlrpc)\b",
+    r"\bimport\s+[^#\n]*\b(os|subprocess|sys|shutil|socket|requests|urllib|pathlib|pickle|pty|code|bdb|pdb|multiprocessing|threading|tempfile|ftplib|smtplib|telnetlib|http|xmlrpc|importlib|builtins|inspect|gc|ctypes)\b",
+    r"\bfrom\s+(os|subprocess|sys|shutil|socket|requests|urllib|pathlib|pickle|pty|code|bdb|pdb|multiprocessing|threading|tempfile|ftplib|smtplib|telnetlib|http|xmlrpc|importlib|builtins|inspect|gc|ctypes)\b",
     # Dangerous built-ins
     r"\beval\s*\(",
     r"\bexec\s*\(",
@@ -77,7 +78,7 @@ DANGEROUS_PATTERNS = [
     r"\bsetattr\s*\(",
     r"\bbreakpoint\s*\(",
     # Dangerous module functions
-    r"\bos\.(system|popen|spawn|remove|unlink|rmdir|mkdir|chmod|chown|kill|exec|fork|pipe)\b",
+    r"\bos\.(system|popen|spawn|remove|unlink|rmdir|mkdir|chmod|chown|kill|exec|fork|pipe|walk|listdir)\b",
     r"\bsubprocess\.(run|call|check_call|check_output|Popen)\b",
     r"\bshutil\.(rmtree|move|copy|copy2|copyfile|copymode|copystat|chown)\b",
     r"\bpickle\.(load|loads)\b",
@@ -229,7 +230,7 @@ try:
     sys.stderr = stderr_capture
 
     # Execute the user's code
-{code}
+{textwrap.indent(code, '    ')}
 
     sys.stdout = original_stdout
     sys.stderr = original_stderr
@@ -257,13 +258,19 @@ except Exception as e:
 
     # Try to execute with timeout
     try:
+        # Filter environment to prevent secret leakage
+        allowed_vars = ["PATH", "LANG", "PYTHONIOENCODING"]
+        filtered_env = {k: os.environ[k] for k in allowed_vars if k in os.environ}
+        filtered_env["PYTHONPATH"] = temp_dir
+        filtered_env["PYTHONIOENCODING"] = "utf-8"
+
         result = subprocess.run(
             [sys.executable, test_file],
             capture_output=True,
             text=True,
             timeout=execution_timeout,
             cwd=temp_dir,
-            env={**os.environ, "PYTHONPATH": temp_dir},
+            env=filtered_env,
         )
 
         stdout = result.stdout


### PR DESCRIPTION
### 🚨 Severity: MEDIUM (Security Enhancement)

### 💡 Vulnerability
The unit test gate was executing untrusted, LLM-generated code samples with the full parent environment (`os.environ`). This allowed any generated code to easily access and potentially exfiltrate sensitive secrets like `OPENAI_API_KEY`. Additionally, the sandbox blocklist was missing several common modules used for sandbox escapes.

### 🎯 Impact
If the teacher model was compromised or manipulated into generating malicious code, it could have stolen API keys or performed unauthorized file system discovery during the automated testing phase of the pipeline.

### 🔧 Fix
1.  **Environment Isolation**: Modified `subprocess.run` in `scripts/03_unit_test_gate.py` to use a strict allowlist of environment variables (`PATH`, `LANG`, `PYTHONIOENCODING`).
2.  **Sandbox Hardening**: Added `importlib`, `builtins`, `inspect`, `gc`, `ctypes`, `os.walk`, and `os.listdir` to `DANGEROUS_PATTERNS`.
3.  **Indentation Fix**: Used `textwrap.indent` to properly wrap injected code, ensuring it runs within the `try...except` security block.
4.  **Bug Fix**: Resolved a `NameError` in `heidi_engine/telemetry.py` that was causing `pytest` failures.

### ✅ Verification
- Verified environment filtering using a custom sample that tried to access `OPENAI_API_KEY`.
- Verified that new dangerous imports are correctly blocked.
- Verified multi-line code execution with the new indentation logic.
- Ran the full `pytest` suite; all 21 tests passed.

---
*PR created automatically by Jules for task [17807543051733523694](https://jules.google.com/task/17807543051733523694) started by @heidi-dang*