### PR TITLE
🛡️ Sentinel: [security improvement] Update secret redaction patterns

### DIFF
--- a/heidi_engine/telemetry.py
+++ b/heidi_engine/telemetry.py
@@ -151,7 +151,9 @@ SECRET_PATTERNS = [
     # Generic API keys and tokens
     (r"ghp_[a-zA-Z0-9]{36}", "[GITHUB_TOKEN]"),
     (r"glpat-[a-zA-Z0-9\-]{20,}", "[GITLAB_TOKEN]"),
-    (r"sk-[a-zA-Z0-9]{20,}", "[OPENAI_KEY]"),
+    (r"sk-[a-zA-Z0-9\-]{20,}", "[OPENAI_KEY]"),
+    (r"xox[baprs]-[a-zA-Z0-9\-]{10,}", "[SLACK_TOKEN]"),
+    (r"AIza[0-9A-Za-z\-_]{35}", "[GOOGLE_API_KEY]"),
     (r"Bearer\s+[\w\-]{20,}", "[BEARER_TOKEN]"),
     (r'(?i)(api[_-]?key|apikey|secret[_-]?key)\s*[:=]\s*["\']?[\w\-]{20,}', "[API_KEY]"),
     (r"AKIA[0-9A-Z]{16}", "[AWS_KEY]"),
@@ -166,7 +168,7 @@ SECRET_PATTERNS = [
 # Keywords that indicate secrets - used for fast-path redaction check.
 # NOTE: Must be kept in sync with SECRET_PATTERNS above.
 _SECRET_INDICATORS = re.compile(
-    r"ghp_|glpat-|sk-|Bearer|api[_-]?key|apikey|secret[_-]?key|AKIA|PRIVATE\s+KEY|OPENSSH|TOKEN|AWS_SECRET",
+    r"ghp_|glpat-|sk-|xox[baprs]|AIza|Bearer|api[_-]?key|apikey|secret[_-]?key|AKIA|PRIVATE\s+KEY|OPENSSH|TOKEN|AWS_SECRET",
     re.IGNORECASE,
 )
 
@@ -733,7 +735,7 @@ def get_state(run_id: Optional[str] = None) -> Dict[str, Any]:
         }
 
     # BOLT OPTIMIZATION: Check thread-safe state cache
-    cached = _state_cache.get(target_run_id, state_file)
+    cached = _state_cache.get(resolved_run_id)
     if cached:
         return cached
 

--- a/scripts/02_validate_clean.py
+++ b/scripts/02_validate_clean.py
@@ -77,7 +77,11 @@ SECRET_PATTERNS = [
     (r"ghp_[a-zA-Z0-9]{36}", "github_token"),
     (r"glpat-[a-zA-Z0-9\-]{20,}", "gitlab_token"),
     # OpenAI API keys
-    (r"sk-[a-zA-Z0-9]{48,}", "openai_key"),
+    (r"sk-[a-zA-Z0-9\-]{20,}", "openai_key"),
+    # Slack tokens
+    (r"xox[baprs]-[a-zA-Z0-9\-]{10,}", "slack_token"),
+    # Google API keys
+    (r"AIza[0-9A-Za-z\-_]{35}", "google_api_key"),
     # Generic high-entropy strings that look like secrets
     (r'["\'][\w+\/]{40,}["\']', "high_entropy"),
     # Passwords in config-like patterns


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Update secret redaction patterns

This PR improves the security of the pipeline by expanding the coverage of secret detection and redaction.

### 💡 Vulnerability:
The previous regex patterns for secret detection were too restrictive for modern credential formats. Specifically:
1. **OpenAI Project Keys**: New `sk-proj-` keys contain hyphens which were not matched by the previous `[a-zA-Z0-9]` character class.
2. **Slack Tokens**: `xoxb-`, `xoxp-`, etc., tokens were not detected.
3. **Google API Keys**: `AIza...` keys were not detected.

### 🎯 Impact:
Sensitive credentials could be leaked into:
1. **Telemetry Logs (`events.jsonl`)**: Redaction would fail for these formats.
2. **Training Datasets (`clean.jsonl`)**: The validation script would fail to drop samples containing these secrets.

### 🔧 Fix:
- Updated `SECRET_PATTERNS` in `heidi_engine/telemetry.py` and `scripts/02_validate_clean.py`.
- Corrected the Slack regex to handle alphanumeric segments and hyphens: `xox[baprs]-[a-zA-Z0-9\-]{10,}`.
- Updated the fast-path `_SECRET_INDICATORS` regex in `telemetry.py` to keep it in sync.
- Resolved a `NameError` in `heidi_engine/telemetry.py` discovered during regression testing.

### ✅ Verification:
- Created a reproduction script to verify that `sk-proj-...` keys are correctly redacted.
- Ran the full test suite (`pytest tests/`) and confirmed all 21 tests passed.
- Verified that the performance optimization in `get_state` was preserved correctly after fixing the `NameError`.

---
*PR created automatically by Jules for task [3232275468190411887](https://jules.google.com/task/3232275468190411887) started by @heidi-dang*