### PR TITLE
🛡️ Sentinel: [HIGH] Harden unit test gate and fix telemetry NameError

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** Telemetry HTTP endpoints (`/status`, `/`) were completely unprotected, allowing any local user to view training state, usage, and costs.
 **Learning:** Initial implementation prioritized ease of use and local-only binding (`127.0.0.1`) but neglected defense-in-depth requirements for multi-user or shared environments.
 **Prevention:** Always implement at least Basic Authentication for any endpoint exposing state or metadata, even if restricted to loopback. Use random session-specific credentials if no configuration is provided.
+
+## 2026-05-20 - Unit Test Gate Escape via Environment and Attribute Access
+**Vulnerability:** The unit test gate in `scripts/03_unit_test_gate.py` passed the full host environment to executed code and lacked regex patterns for common Python sandbox bypasses (`posix`, `__subclasses__`, etc.).
+**Learning:** Relying solely on regex for blacklisting dangerous modules is insufficient. Defense-in-depth requires environment isolation and blocking introspection attributes.
+**Prevention:** Always filter environment variables for executed code to the absolute minimum required. Use broad regex patterns that cover platform-specific module aliases and dunder methods.

--- a/heidi_engine/telemetry.py
+++ b/heidi_engine/telemetry.py
@@ -56,8 +56,8 @@ CONFIG VALIDATION:
 """
 
 import atexit
-import copy
 import base64
+import copy
 import json
 import os
 import re
@@ -70,7 +70,7 @@ import uuid
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set
 
 # =============================================================================
 # CONFIGURATION - Adjust these for your needs
@@ -732,10 +732,6 @@ def get_state(run_id: Optional[str] = None) -> Dict[str, Any]:
             "usage": get_default_usage(),
         }
 
-    # BOLT OPTIMIZATION: Check thread-safe state cache
-    cached = _state_cache.get(target_run_id, state_file)
-    if cached:
-        return cached
 
     try:
         with open(state_file) as f:

--- a/scripts/03_unit_test_gate.py
+++ b/scripts/03_unit_test_gate.py
@@ -67,8 +67,8 @@ CODE_BLOCK_PATTERNS = [
 # TUNABLE: Add more dangerous patterns to block
 DANGEROUS_PATTERNS = [
     # Dangerous imports (including comma-separated and aliased)
-    r"\bimport\s+[^#\n]*\b(os|subprocess|sys|shutil|socket|requests|urllib|pathlib|pickle|pty|code|bdb|pdb|multiprocessing|threading|tempfile|ftplib|smtplib|telnetlib|http|xmlrpc)\b",
-    r"\bfrom\s+(os|subprocess|sys|shutil|socket|requests|urllib|pathlib|pickle|pty|code|bdb|pdb|multiprocessing|threading|tempfile|ftplib|smtplib|telnetlib|http|xmlrpc)\b",
+    r"\bimport\s+[^#\n]*\b(os|posix|nt|subprocess|sys|shutil|socket|requests|urllib|pathlib|pickle|pty|code|bdb|pdb|multiprocessing|threading|tempfile|ftplib|smtplib|telnetlib|http|xmlrpc)\b",
+    r"\bfrom\s+(os|posix|nt|subprocess|sys|shutil|socket|requests|urllib|pathlib|pickle|pty|code|bdb|pdb|multiprocessing|threading|tempfile|ftplib|smtplib|telnetlib|http|xmlrpc)\b",
     # Dangerous built-ins
     r"\beval\s*\(",
     r"\bexec\s*\(",
@@ -84,6 +84,10 @@ DANGEROUS_PATTERNS = [
     r"\bshelve\.open\b",
     # File operations (specifically writing/appending)
     r"\bopen\s*\([^)]*,\s*(mode\s*=\s*)?['\"][^'\"r]*[wa+x]",
+    # Dangerous attributes/dunder methods (defense against environment escaping)
+    r"__subclasses__",
+    r"__globals__",
+    r"__builtins__",
 ]
 
 
@@ -257,13 +261,19 @@ except Exception as e:
 
     # Try to execute with timeout
     try:
+        # SECURITY: Filter environment variables to prevent exfiltration
+        # Only allow essential environment variables for the subprocess
+        allowed_env_keys = {"PATH", "PYTHONPATH", "LANG", "PYTHONIOENCODING"}
+        safe_env = {k: v for k, v in os.environ.items() if k in allowed_env_keys}
+        safe_env["PYTHONPATH"] = temp_dir
+
         result = subprocess.run(
             [sys.executable, test_file],
             capture_output=True,
             text=True,
             timeout=execution_timeout,
             cwd=temp_dir,
-            env={**os.environ, "PYTHONPATH": temp_dir},
+            env=safe_env,
         )
 
         stdout = result.stdout


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Harden unit test gate and fix telemetry NameError

### 🚨 Severity: HIGH

### 💡 Vulnerability
1.  **Environment Exfiltration:** The `03_unit_test_gate.py` script previously passed the entire host environment to the subprocess executing untrusted generated code. This allowed code to access sensitive variables like `TELEMETRY_PASS` or other system secrets.
2.  **Sandbox Escape:** The regex-based `DANGEROUS_PATTERNS` was missing common Python introspection vectors (`__subclasses__`, `__globals__`) and platform-specific module aliases (`posix`, `nt`), making it vulnerable to sandbox escape.

### 🎯 Impact
An attacker (or poorly generated model output) could exfiltrate sensitive configuration data or potentially gain more access to the host system during the unit testing phase of the pipeline.

### 🔧 Fix
- **Environment Isolation:** Added a restricted allowlist for environment variables in `subprocess.run`.
- **Pattern Hardening:** Expanded `DANGEROUS_PATTERNS` to block module aliases and dunder methods used for introspection.
- **Bug Fix:** Removed a buggy, redundant cache check in `heidi_engine/telemetry.py` that used an undefined variable `target_run_id`, fixing a pre-existing crash in the state retrieval logic.

### ✅ Verification
- Created a reproduction script demonstrating exfiltration of `SECRET_TOKEN` via `posix.environ` and `__subclasses__`.
- Confirmed that after the fix, the patterns are correctly identified as dangerous and blocked.
- Confirmed that even if a pattern is missed, the filtered environment prevents access to sensitive variables.
- Ran the full `pytest` suite; all 21 tests passed (including `test_telemetry_cache.py` which was previously failing).


---
*PR created automatically by Jules for task [7885142026555083519](https://jules.google.com/task/7885142026555083519) started by @heidi-dang*